### PR TITLE
feature/show day types

### DIFF
--- a/components/schedule/schedule-utils.ts
+++ b/components/schedule/schedule-utils.ts
@@ -106,6 +106,11 @@ const updateTimeslotDurations = (timeslots: TimeSlot[], rooms: string[]) => {
       maxDuration = Math.max(maxDuration, duration);
     });
 
+    // this happens when there's no next row
+    if (maxDuration == 0) {
+      maxDuration = Math.max(...row);
+    }
+
     timeslots[index].duration = maxDuration;
   });
 };

--- a/components/schedule/schedule-utils.ts
+++ b/components/schedule/schedule-utils.ts
@@ -1,5 +1,5 @@
 import { timeToNumber } from "./time-helpers";
-import { OrphanTimeSlot, Schedule, Session, TimeSlot } from "./types";
+import { OrphanTimeSlot, Session, TimeSlot } from "./types";
 
 const TYPES_MAP = {
   "Talk [in-person]": "talk",
@@ -13,14 +13,6 @@ const AUDIENCE_MAP = {
   some: "intermediate",
   expert: "advanced",
 };
-
-const mode = (arr: number[]) =>
-  arr
-    .sort(
-      (a, b) =>
-        arr.filter((v) => v === a).length - arr.filter((v) => v === b).length
-    )
-    .pop();
 
 const convertTalk = (talk: any): Session => {
   const time = timeToNumber(talk.time);
@@ -212,3 +204,6 @@ export const getScheduleForDay = async ({
 
   return { slots, rooms };
 };
+
+export const getDayType = (day: string) =>
+  ["2022-07-11", "2022-07-12"].includes(day) ? "Tutorials" : "Talks";

--- a/components/schedule/schedule-utils.ts
+++ b/components/schedule/schedule-utils.ts
@@ -84,7 +84,6 @@ const convertTalk = (talk: any): Session => {
 };
 
 const updateTimeslotDurations = (timeslots: TimeSlot[], rooms: string[]) => {
-  const timeslotDurations: number[] = [];
   const sessionsMatrix: number[][] = [];
 
   timeslots.forEach((timeslot) => {

--- a/components/schedule/schedule.tsx
+++ b/components/schedule/schedule.tsx
@@ -23,7 +23,7 @@ const ROW_HEIGHT = 25;
 const HEADING_ROWS = 2;
 const BREAK_ROWS = 3;
 const SESSION_ROWS = 6;
-const SESSION_ROWS_TUTORIALS = 4;
+const SESSION_ROWS_TUTORIALS = 3;
 
 const getColumnForSession = (session: { rooms: string[] }, rooms: string[]) => {
   const roomIndexes = session.rooms.map((room) => rooms.indexOf(room)).sort();

--- a/components/schedule/session.tsx
+++ b/components/schedule/session.tsx
@@ -38,7 +38,7 @@ export const Session = ({
   const firstSpeaker = speakers?.[0];
 
   return (
-    <div className="talk" style={style} onClick={() => console.log(session)}>
+    <div className="talk" style={style}>
       <header className={`${session.audience || ""} session-${session.type}`}>
         <p className={`talk__rating`}>{getHeaderText(session)}</p>
 

--- a/pages/schedule/[day].tsx
+++ b/pages/schedule/[day].tsx
@@ -15,12 +15,19 @@ export default function SchedulePage({
   schedule,
 }: {
   day: string;
-  days: string[];
+  days: { day: string; type: string }[];
   schedule: ScheduleType;
 }) {
   const handleDaySelected = useCallback((event) => {
     window.location.href = `/schedule/${event.target.value}`;
   }, []);
+
+  const sortedDays = days.sort((a, b) => {
+    return (
+      parse(a.day, "yyyy-MM-dd", new Date()).getTime() -
+      parse(b.day, "yyyy-MM-dd", new Date()).getTime()
+    );
+  });
 
   return (
     <Layout>
@@ -34,19 +41,17 @@ export default function SchedulePage({
             onChange={handleDaySelected}
             defaultValue={day}
           >
-            {days
-              .map((day) => parse(day, "yyyy-MM-dd", new Date()))
-              .sort((a, b) => a.getTime() - b.getTime())
-              .map((date) => {
-                const isoDate = format(date, "yyyy-MM-dd");
-                const dateText = format(date, "eeee, do MMMM, yyyy");
+            {sortedDays.map(({ day, type }) => {
+              const date = parse(day, "yyyy-MM-dd", new Date());
+              const isoDate = format(date, "yyyy-MM-dd");
+              const dateText = format(date, "eeee, do MMMM, yyyy");
 
-                return (
-                  <option key={isoDate} value={isoDate}>
-                    {dateText}
-                  </option>
-                );
-              })}
+              return (
+                <option key={isoDate} value={isoDate}>
+                  {dateText} - {type}
+                </option>
+              );
+            })}
           </select>
         </article>
 
@@ -74,7 +79,10 @@ export async function getStaticProps({ params }: { params: { day: string } }) {
     props: {
       day: params.day,
       schedule: daySchedule,
-      days: Object.keys(schedule.days),
+      days: Object.entries(schedule.days).map(([day, _]) => ({
+        day,
+        type: ["2022-07-11", "2022-07-12"].includes(day) ? "Workshops" : "Talks",
+      })),
     },
     revalidate: 60,
   };

--- a/pages/schedule/[day].tsx
+++ b/pages/schedule/[day].tsx
@@ -5,7 +5,10 @@ import { Layout } from "../../components/layout";
 import { useCallback } from "react";
 import { fetchSchedule } from "../../lib/schedule";
 
-import { getScheduleForDay } from "../../components/schedule/schedule-utils";
+import {
+  getDayType,
+  getScheduleForDay,
+} from "../../components/schedule/schedule-utils";
 import { Schedule } from "../../components/schedule/schedule";
 import { Schedule as ScheduleType } from "../../components/schedule/types";
 
@@ -28,6 +31,8 @@ export default function SchedulePage({
       parse(b.day, "yyyy-MM-dd", new Date()).getTime()
     );
   });
+
+  const dayType = getDayType(day);
 
   return (
     <Layout>
@@ -55,7 +60,7 @@ export default function SchedulePage({
           </select>
         </article>
 
-        <Schedule schedule={schedule} />
+        <Schedule schedule={schedule} dayType={dayType} />
       </main>
     </Layout>
   );
@@ -81,7 +86,7 @@ export async function getStaticProps({ params }: { params: { day: string } }) {
       schedule: daySchedule,
       days: Object.entries(schedule.days).map(([day, _]) => ({
         day,
-        type: ["2022-07-11", "2022-07-12"].includes(day) ? "Workshops" : "Talks",
+        type: getDayType(day),
       })),
     },
     revalidate: 60,


### PR DESCRIPTION
This PR shows the day type after the day in the select:

<img width="806" alt="image" src="https://user-images.githubusercontent.com/667029/173630515-25d06e2e-77f8-48e4-a0fd-b38f75c5bdbc.png">

And also scales the sizes of the events when we are working with only tutorials (left is after, right is before):

<img width="1171" alt="image" src="https://user-images.githubusercontent.com/667029/173630690-705756ea-121c-4b6a-bfb1-a1437495237a.png">
