### PR TITLE
Show user timezone on schedule and session page

### DIFF
--- a/components/datetime.tsx
+++ b/components/datetime.tsx
@@ -1,0 +1,19 @@
+import format from "date-fns/format";
+import parseISO from "date-fns/parseISO";
+import { formatInTimeZone } from "date-fns-tz";
+
+export const Datetime = ({
+  datetime,
+  useUserTimezone,
+  format: pattern,
+}: {
+  datetime: Date;
+  useUserTimezone: boolean;
+  format: string;
+}) => {
+  const formattedDate = useUserTimezone
+    ? format(datetime, pattern)
+    : formatInTimeZone(datetime, "Europe/Dublin", pattern);
+
+  return <time dateTime={datetime.toISOString()}>{formattedDate}</time>;
+};

--- a/components/schedule/schedule.tsx
+++ b/components/schedule/schedule.tsx
@@ -1,5 +1,6 @@
+import { parseISO } from "date-fns";
+import { Datetime } from "../datetime";
 import { Break } from "./break";
-import { getDayType } from "./schedule-utils";
 import { Session } from "./session";
 import { numberToTime } from "./time-helpers";
 import {
@@ -7,6 +8,26 @@ import {
   Session as SessionType,
   TimeSlot,
 } from "./types";
+
+const TalkTime = ({ time }: { time: number }) => {
+  const timeAsString = numberToTime(time);
+
+  const isoTime = parseISO(`2022-07-13T${timeAsString}:00+01:00`);
+
+  return (
+    <div className="talk-time">
+      <div>
+        <Datetime datetime={isoTime} useUserTimezone={false} format={"HH:mm"} />
+        <div className="timezone">(Dublin)</div>
+      </div>
+
+      <div>
+        <Datetime datetime={isoTime} useUserTimezone={true} format={"HH:mm"} />
+        <div className="timezone">(You)</div>
+      </div>
+    </div>
+  );
+};
 
 const map = (
   value: number,
@@ -139,7 +160,7 @@ const ScheduleSlot = ({
           "--grid-row": `${row.start} / ${row.end}`,
         }}
       >
-        {numberToTime(slot.time)}
+        <TalkTime time={slot.time} />
       </div>
 
       {slot.sessions.map((session) => {
@@ -186,7 +207,7 @@ const Orphan = ({
           ...style,
         }}
       >
-        {numberToTime(session.time)}
+        <TalkTime time={session.time} />
       </div>
 
       <Session

--- a/package-lock.json
+++ b/package-lock.json
@@ -8,6 +8,7 @@
       "dependencies": {
         "@mdx-js/react": "^2.0.0",
         "date-fns": "^2.28.0",
+        "date-fns-tz": "^1.3.5",
         "glob": "^8.0.3",
         "gray-matter": "^4.0.3",
         "next": "12.0.10",
@@ -2098,6 +2099,14 @@
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/date-fns"
+      }
+    },
+    "node_modules/date-fns-tz": {
+      "version": "1.3.5",
+      "resolved": "https://registry.npmjs.org/date-fns-tz/-/date-fns-tz-1.3.5.tgz",
+      "integrity": "sha512-SNhl/fWe7i2HoIB9ejLZhEEJ6ZtRRpOBbzizFrq11K2/iceS9Nk7fPN2VTYVOMgFB9u0f3eidSC4n1xaRONW2A==",
+      "peerDependencies": {
+        "date-fns": ">=2.0.0"
       }
     },
     "node_modules/debug": {
@@ -8171,6 +8180,12 @@
       "version": "2.28.0",
       "resolved": "https://registry.npmjs.org/date-fns/-/date-fns-2.28.0.tgz",
       "integrity": "sha512-8d35hViGYx/QH0icHYCeLmsLmMUheMmTyV9Fcm6gvNwdw31yXXH+O85sOBJ+OLnLQMKZowvpKb6FgMIQjcpvQw=="
+    },
+    "date-fns-tz": {
+      "version": "1.3.5",
+      "resolved": "https://registry.npmjs.org/date-fns-tz/-/date-fns-tz-1.3.5.tgz",
+      "integrity": "sha512-SNhl/fWe7i2HoIB9ejLZhEEJ6ZtRRpOBbzizFrq11K2/iceS9Nk7fPN2VTYVOMgFB9u0f3eidSC4n1xaRONW2A==",
+      "requires": {}
     },
     "debug": {
       "version": "4.3.3",

--- a/package.json
+++ b/package.json
@@ -12,6 +12,7 @@
   "dependencies": {
     "@mdx-js/react": "^2.0.0",
     "date-fns": "^2.28.0",
+    "date-fns-tz": "^1.3.5",
     "glob": "^8.0.3",
     "gray-matter": "^4.0.3",
     "next": "12.0.10",

--- a/pages/session/[slug].tsx
+++ b/pages/session/[slug].tsx
@@ -4,6 +4,7 @@ import { serialize } from "next-mdx-remote/serialize";
 import { fetchSessions } from "../../lib/sessions";
 import parseISO from "date-fns/parseISO";
 import { format } from "date-fns";
+import { Datetime } from "../../components/datetime";
 
 type Speaker = {
   code: string;
@@ -61,8 +62,22 @@ export default function Page({
             ) : null}
             {start ? (
               <>
-                <dt>Start:</dt>
-                <dd>{format(start, "HH:mm 'on' dd MMMM yyyy")}</dd>
+                <dt>Start (Dublin time):</dt>
+                <dd>
+                  <Datetime
+                    datetime={start}
+                    format="HH:mm 'on' dd MMMM yyyy"
+                    useUserTimezone={false}
+                  />
+                </dd>
+                <dt>Start (your time):</dt>
+                <dd>
+                  <Datetime
+                    datetime={start}
+                    format="HH:mm 'on' dd MMMM yyyy"
+                    useUserTimezone={true}
+                  />
+                </dd>
               </>
             ) : null}
             <dt>Duration:</dt>
@@ -97,7 +112,7 @@ export default function Page({
           </h2>
 
           {session.speakers.map((speaker) => (
-            <div>
+            <div key={speaker.code}>
               <p className="large">{speaker.name}</p>
               <MDXRemote {...speaker.biographySource} />
             </div>

--- a/styles/main.css
+++ b/styles/main.css
@@ -3059,3 +3059,37 @@ button[name="vote"]:hover {
 .session-card__author {
   font-weight: bold;
 }
+
+.talk-time,
+.talk-time div {
+  text-align: center;
+  padding: 0 !important;
+}
+
+.talk-time {
+  display: flex;
+  justify-content: center;
+}
+
+.talk-time > div {
+  margin-left: 2em;
+}
+
+@media all and (min-width: 1180px) {
+  .talk-time {
+    display: block;
+  }
+
+  .talk-time > div {
+    margin-left: 0;
+  }
+}
+
+.talk-time time {
+  display: block;
+}
+
+.talk-time .timezone {
+  font-size: 0.7rem;
+  margin-bottom: 1em;
+}


### PR DESCRIPTION
This PR add local time in the schedule and sessions:

<img width="492" alt="image" src="https://user-images.githubusercontent.com/667029/177217150-af453ab1-72fe-4bbe-a322-eedc394e7755.png">


<img width="812" alt="image" src="https://user-images.githubusercontent.com/667029/177217164-8208a47e-5ea6-4d33-a1f8-cb091540ef77.png">

you can view it here: https://ep2022-git-feature-timezone-europython-society.vercel.app/schedule/2022-07-11