### PR TITLE
Social event Page under "Events"

### DIFF
--- a/data/links.json
+++ b/data/links.json
@@ -101,6 +101,10 @@
         {
           "name": "PyLadies Lunch",
           "path": "/pyladies-lunch"
+        },
+        {
+          "name": "Social Event",
+          "path": "/social-event"
         }
       ]
     },

--- a/data/pages-content/social-event.md
+++ b/data/pages-content/social-event.md
@@ -1,0 +1,39 @@
+---
+title: Social Event
+subtitle:
+  Come to the EuroPython 2022 social event on Tuesday evening!
+---
+## EuroPython 2022 Social Event ##
+After the keynotes and talks on Tusday, July 12, we’ve organized a social event for you at the conference venue, 
+the Dublin Convention Centre (CCD). Starting at 20:00 CEST you can join us for an evening party with food, drinks
+and live entertainment.
+
+## Social Event Ticket ##
+**Please note: The social event is not included in the conference ticket!**
+
+Tickets for the social event are available in our [ticket store](https://ep2022.europython.eu/tickets) at a price of 10 €. 
+We only have a limited number of tickets available, so book early if you want to be sure to get a ticket!
+
+As for our regular tickets, you can pay using a debit or credit card. Unless otherwise mentioned, all prices include 23% Irish VAT.
+
+  <ButtonWithTitle title="Interested in join us?" text="Buy your ticket now!" href="https://ep2022.europython.eu/tickets" />
+
+## Social Event Summary ##
+
+- Where: The conference venue, the CCD.
+- When: Tuesday July 12, starting at 20:00 CEST
+- Price: 10 € (**not refundable**). The ticket includes free food, two hours of free drinks (you have to pay for drinks yourself after that) and live entertainment.
+- Schedule: 
+    - Entrance will open starting at 19:00 CEST
+    - Party will start at 20:00 CEST
+    - Closing: 23:30 CEST
+
+---
+<div style={{textAlign: "center"}}>
+<Note>Big THANK YOU to our... </Note>
+</div>
+
+### Social Event Sponsor ###
+<a className="img" target="_blank" href="https://jobs.kiwi.com/">
+<img src="/img/logos/sponsor_logos/kiwi.svg"  />
+</a>


### PR DESCRIPTION
This PR add a single page under /social-event and the corresponding link in the menu. The /social-event page has general information about the Tuesday social event, a button to buy tickets and a thank you to our sponsor.