### PR TITLE
Fix project Mu link in mentored sprint

### DIFF
--- a/data/pages-content/mentored-sprint.md
+++ b/data/pages-content/mentored-sprint.md
@@ -50,7 +50,7 @@ Projects that have shown interested in appearing in the mentored sprint:
 * [OpenMetaData](https://github.com/open-metadata/OpenMetadata)
 * [CircuitPython](https://github.com/adafruit/circuitpython)
 * [scikit-learn](https://github.com/scikit-learn/scikit-learn)
-* [Mu](https://github.com/scikit-learn/scikit-learn)
+* [Mu](https://github.com/mu-editor/mu)
 * [Hypothesis](https://github.com/HypothesisWorks/hypothesis)
 * [Strawberry](https://github.com/strawberry-graphql/strawberry)
 


### PR DESCRIPTION
I hope this is the `Mu` project you were referring to :)