### PR TITLE
Add clacks of remembrance to our base template

### DIFF
--- a/components/clacks.tsx
+++ b/components/clacks.tsx
@@ -1,0 +1,19 @@
+// https://xclacksoverhead.org/home/about
+// we're using `dangerouslySetInnerHTML` here because nor Next.js nor React support
+// html comments in JSX, and we want to keep the In remembrance section in the
+// output of the page
+
+export const Clacks = () => {
+  return (
+    <head
+      dangerouslySetInnerHTML={{
+        __html: `
+      <!-- In remembrance -->
+      <meta httpEquiv="X-Clacks-Overhead" content="GNU John Pinner" />
+      <meta httpEquiv="X-Clacks-Overhead" content="GNU Rob Collins" />
+      <meta httpEquiv="X-Clacks-Overhead" content="GNU Oier Etxaniz" />
+    `,
+      }}
+    ></head>
+  );
+};

--- a/components/meta.tsx
+++ b/components/meta.tsx
@@ -1,4 +1,5 @@
 import Head from "next/head";
+import { Clacks } from "./clacks";
 export const Meta = ({
   title = "EuroPython 2023 | July 17th-23rd 2023 | Prague, Czech Republic & Remote",
   path,
@@ -55,6 +56,8 @@ export const Meta = ({
       <meta property="twitter:title" content={title} />
       <meta property="twitter:description" content="" />
       <meta property="twitter:image" content={imageUrl} />
+
+      <Clacks />
     </Head>
   );
 };

--- a/pages/index.tsx
+++ b/pages/index.tsx
@@ -42,6 +42,10 @@ export default function IndexPage() {
         <meta property="twitter:title" content="EuroPython 2023 | July 17th-23rd 2023 | Prague, Czech Republic & Remote" />
         <meta property="twitter:description" content="" />
         <meta property="twitter:image" content={imageUrl} />
+        <!-- In remembrance -->
+        <meta http-equiv="X-Clacks-Overhead" content="GNU John Pinner">
+        <meta http-equiv="X-Clacks-Overhead" content="GNU Rob Collins">
+        <meta http-equiv="X-Clacks-Overhead" content="GNU Oier Etxaniz">
       </Head>
 
       <div className="flex items-center justify-center content-center min-h-screen">

--- a/pages/index.tsx
+++ b/pages/index.tsx
@@ -1,9 +1,20 @@
 import { Hero } from "../components/hero";
 
 import Head from "next/head";
+import { useRef, useEffect } from "react";
+import { Clacks } from "components/clacks";
 
 export default function IndexPage() {
   const imageUrl = "https://ep2023.europython.eu/social-cards/default.png";
+  const metaRef = useRef<HTMLMetaElement>(null);
+
+  useEffect(() => {
+    console.log("metaRef", metaRef.current);
+    if (metaRef.current) {
+      // add comment before meta tag
+      metaRef.current.before(document.createComment("GNU Terry Pratchett"));
+    }
+  }, []);
 
   return (
     <>
@@ -24,8 +35,14 @@ export default function IndexPage() {
           href="http://blog.europython.eu/rss"
         />
 
-        <title>EuroPython 2023 | July 17th-23rd 2023 | Prague, Czech Republic & Remote</title>
-        <meta name="title" content="EuroPython 2023 | July 17th-23rd 2023 | Prague, Czech Republic & Remote" />
+        <title>
+          EuroPython 2023 | July 17th-23rd 2023 | Prague, Czech Republic &
+          Remote
+        </title>
+        <meta
+          name="title"
+          content="EuroPython 2023 | July 17th-23rd 2023 | Prague, Czech Republic & Remote"
+        />
         <meta name="description" content="" />
         <meta name="author" content="EuroPython" />
 
@@ -33,19 +50,23 @@ export default function IndexPage() {
 
         <meta property="og:type" content="website" />
         <meta property="og:url" content="https://ep2023.europython.eu" />
-        <meta property="og:title" content="EuroPython 2023 | July 17th-23rd 2023 | Prague, Czech Republic & Remote" />
+        <meta
+          property="og:title"
+          content="EuroPython 2023 | July 17th-23rd 2023 | Prague, Czech Republic & Remote"
+        />
         <meta property="og:description" content="" />
         <meta property="og:image" content={imageUrl} />
 
         <meta property="twitter:card" content="summary_large_image" />
         <meta property="twitter:url" content="https://ep2023.europython.eu" />
-        <meta property="twitter:title" content="EuroPython 2023 | July 17th-23rd 2023 | Prague, Czech Republic & Remote" />
+        <meta
+          property="twitter:title"
+          content="EuroPython 2023 | July 17th-23rd 2023 | Prague, Czech Republic & Remote"
+        />
         <meta property="twitter:description" content="" />
         <meta property="twitter:image" content={imageUrl} />
-        <!-- In remembrance -->
-        <meta http-equiv="X-Clacks-Overhead" content="GNU John Pinner" />
-        <meta http-equiv="X-Clacks-Overhead" content="GNU Rob Collins" />
-        <meta http-equiv="X-Clacks-Overhead" content="GNU Oier Etxaniz" />
+
+        <Clacks />
       </Head>
 
       <div className="flex items-center justify-center content-center min-h-screen">

--- a/pages/index.tsx
+++ b/pages/index.tsx
@@ -43,9 +43,9 @@ export default function IndexPage() {
         <meta property="twitter:description" content="" />
         <meta property="twitter:image" content={imageUrl} />
         <!-- In remembrance -->
-        <meta http-equiv="X-Clacks-Overhead" content="GNU John Pinner">
-        <meta http-equiv="X-Clacks-Overhead" content="GNU Rob Collins">
-        <meta http-equiv="X-Clacks-Overhead" content="GNU Oier Etxaniz">
+        <meta http-equiv="X-Clacks-Overhead" content="GNU John Pinner" />
+        <meta http-equiv="X-Clacks-Overhead" content="GNU Rob Collins" />
+        <meta http-equiv="X-Clacks-Overhead" content="GNU Oier Etxaniz" />
       </Head>
 
       <div className="flex items-center justify-center content-center min-h-screen">


### PR DESCRIPTION
Context: In the Terry Pratchett novel "Going Postal", a telegraph-style system known as "Clacks" was used to pass the name of a deceased character endlessly back and forth, keeping their memory alive. But where the book had "GNU John Dearheart" -- the prefix being a basic code to instruct clacksmen to pass on, not file, and return the message -- we add meta headers to our base template in a silent but appropriately geeky tribute and act of remembrance to those in our EuroPython family we have lost.