### PR TITLE
Add Google cloud to sponsors.json

### DIFF
--- a/data/sponsors.json
+++ b/data/sponsors.json
@@ -30,6 +30,11 @@
           "name": "numberly",
           "url": "https://numberly.com/en/",
           "logo": "/img/logos/sponsor_logos/numberly.svg"
+        },
+        {
+          "name": "google cloud",
+          "url": "https://cloud.google.com/",
+          "logo": "/img/logos/sponsor_logos/googlecloud.svg"
         }
       ]
     },


### PR DESCRIPTION
TODO: we'll need to change the URL to https://cloud.google.com/developers/europython  NOT Live until July 12, 2023