### PR TITLE
Indicate that finaid applications are closed

### DIFF
--- a/app/page.tsx
+++ b/app/page.tsx
@@ -84,10 +84,10 @@ export default async function IndexPage() {
 
       <div className="mt-40 px-6">
         <HeroWithCTA
-          ctaTitle="Support EuroPython:"
+          ctaTitle="The Sprint Weekend is On"
           ctaButton={
-            <ButtonLink href="/sponsor">
-              Contact the Sponsorship Team!
+            <ButtonLink href="/sprints">
+              Submit your sprint now!
             </ButtonLink>
           }
         >

--- a/data/deadlines/02_finaid.md
+++ b/data/deadlines/02_finaid.md
@@ -1,8 +1,0 @@
----
-title: Financial Aid
-subtitle: Open until 21st May
-url: /finaid
-image: /images/cards/finaid1.jpeg
----
-EuroPython is for everyone in our community, no matter your circumstances.
-Please check out the Financial Aid page if you need help and support to attend.

--- a/data/deadlines/02_sponsorship.md
+++ b/data/deadlines/02_sponsorship.md
@@ -1,0 +1,7 @@
+---
+title: Become a Sponsor
+subtitle: Support the Community
+url: /sponsor
+image: /img/hall_rotated.png
+---
+Here's your chance to support the world's oldest Python conference in the booming tech hub Prague and showcase your company to the diverse Python Communities!

--- a/data/pages-content/faq.md
+++ b/data/pages-content/faq.md
@@ -18,7 +18,7 @@ subtitle: Frequently Asked Questions about EuroPython
 <li><b>2023-04-14</b>: Community Voting ends </li>
 <li><b>2023-05-09</b>: [Sprints Venue & Info](/sprints) Announced </li>
 <li><b>2023-05-16</b>: [List of Session](/sessions) Published</li>
-<li><b>2023-05-22</b>: Financial Aid Programme Closes </li>
+<li><b>2023-05-21</b>: Financial Aid Programme Closes </li>
 
 </ul>
 

--- a/data/pages-content/faq.md
+++ b/data/pages-content/faq.md
@@ -17,12 +17,13 @@ subtitle: Frequently Asked Questions about EuroPython
 <li><b>2023-03-31</b>: [Sponsorship](/sponsor) Early Bird Discount Ends </li>
 <li><b>2023-04-14</b>: Community Voting ends </li>
 <li><b>2023-05-09</b>: [Sprints Venue & Info](/sprints) Announced </li>
+<li><b>2023-05-16</b>: [List of Session](/sessions) Published</li>
+<li><b>2023-05-22</b>: Financial Aid Programme Closes </li>
 
 </ul>
 
 <ul className="milestone-todo">
-<li><b>The week of 2023-05-14</b>: List of Session Published</li>
-<li><b>2023-06-01</b>: First-Time Speaker's Workshop </li>
+<li><b>2023-06-01</b>: [First-Time Speaker's Workshop](/mentorship#first-time-speaker-workshop---thursday-1-june-2023-1800-cest) </li>
 <li><b>2023-07-17</b>: Together at EuroPython 2023! 🎊 </li>
 </ul>
 
@@ -83,7 +84,7 @@ We encourage and trust you to pick a fair ticket tier that fits your personal ci
 
 ## **Q. Is there a Financial Aid Programme for EuroPython 2023?**
 
-A. Yes, our [Financial Aid Programme](/finaid) for in-person participation is open for application until 21 May. If you need help to attend the conference, you are most welcome to apply.
+A. Yes, our [Financial Aid Programme](/finaid) for in-person participation was open for application until 21 May. It is now closed after receiving record-high applications. We are very proud to be supporting so many Pythonistas to attend the conference.
 
 ## **Q. Do you provide childcare?**
 

--- a/data/pages-content/finaid.md
+++ b/data/pages-content/finaid.md
@@ -26,7 +26,7 @@ EuroPython 2023.
 </div>
 
 
-The EuroPython Society are sponsoring the Financial Aid Programme with €20,000 this year.
+The EuroPython Society are sponsoring the Financial Aid Programme with €25,000 this year.
 
 If you want to support EuroPython and its efforts to make EuroPython accessible
 to everyone, please consider sponsoring EuroPython by reaching out to

--- a/data/pages-content/finaid.md
+++ b/data/pages-content/finaid.md
@@ -12,7 +12,8 @@ As part of our commitment to the Python community, we are pleased to announce
 that we offer special grants for people in need of financial aid to attend
 EuroPython.
 
-You’ll find all the information you need to apply for such a grant below.
+**Note:** We are no longer accepting Financial Aid applications for 
+EuroPython 2023.
 
 ---
 
@@ -67,14 +68,16 @@ for a grant:
 
 ## How to apply
 
-You can apply for Financial Aid by filling out the
-[application form][application-form].
+The deadline for submitting Financial Aid applications has passed. You can no
+longer apply for Financial Aid for EuroPython 2023.
 
-The data we collect on this form will exclusively be used by our Financial Aid
-team for the selection of grant recipients and the processing of financial
-aid refunds. No data is passed on to third parties, except to our accountants
-and the bank in order to process the refunds. We use Google Forms for the
-processing and Google Drive for storing the relevant information.
+### Privacy Policy
+
+The data we collect on the application form will exclusively be used by our
+Financial Aid team for the selection of grant recipients and the processing of
+financial aid refunds. No data is passed on to third parties, except to our
+accountants and the bank in order to process the refunds. We use Google Forms
+for the processing and Google Drive for storing the relevant information.
 
 For more details on our privacy policies, please see our
 [privacy policy][privacy-policy].
@@ -239,7 +242,6 @@ See you at EuroPython in Prague!
 
 ---
 
-[application-form]: https://forms.gle/iWvoFyb3XwZRVWpj8
 [privacy-policy]: https://www.europython-society.org/privacy/
 [AoE]: https://en.wikipedia.org/wiki/Anywhere_on_Earth
 [email-finaid]: mailto:finaid@europython.eu


### PR DESCRIPTION
I've added a few lines indicating that we are no longer accepting financial aid applications. I've also moved the privacy policy section into its own section, as it's no longer connected directly to a link to the form.

~~Note: Applications are not closed yet. The deadline is 21 May 2023 Anywhere On Earth, which translates to 22 May 2023 at 12:00 UTC (or 14:00 CEST). We should not merge this before then. I'll change the "draft" status to non-draft after the deadline has passed.~~

Edit: The deadline has passed, and the form is closed. I've marked this PR as ready for review.