### PR TITLE
Remove call for contributors link

### DIFF
--- a/data/home/intro.md
+++ b/data/home/intro.md
@@ -9,7 +9,4 @@ the vibrant Bohemian city Prague. We'll be together, celebrating our shared pass
 Call for Proposals, Mentorship Programme, Financial Aid Programme
 will be starting in February 2024
 
-Want to contribute to EuroPython 2024?! Click on the link
-[https://bitly.ws/3cBDo](https://bitly.ws/3cBDo)
-
 If you have any questions, feel free to contact us at [helpdesk@europython.eu](mailto:helpdesk@europython.eu).


### PR DESCRIPTION
After the deadline is passed for the call for contributors I think is ok to remove any references from the home page