### PR TITLE
Minor content updates

### DIFF
--- a/src/content/pages/cfp.mdx
+++ b/src/content/pages/cfp.mdx
@@ -5,13 +5,13 @@ subtitle: EuroPython Call for Proposals
 # Call for Proposals
 
 <div style={{textAlign: "center", marginBottom: 10}}>
-**EuroPython 2024 Call for Proposals (CFP) is Open.**
+**EuroPython 2024 Call for Proposals (CFP) is now Closed**
 
-It will be running between
-**Wednesday, 14th February 2024** and **Wednesday,** <s>6th</s> **13th, March 2024**
+It was running between
+**Wednesday, 14th February 2024** and **Wednesday, 13th, March 2024**
 [Anywhere on Earth](https://en.wikipedia.org/wiki/Anywhere_on_Earth)
 
-<ButtonLink href="https://program.europython.eu">Submit your proposal now!🐍</ButtonLink>
+<ButtonLink>Form closed. Thank your for your participation and contribution! 🐍</ButtonLink>
 </div>
 ---
 

--- a/src/content/pages/cfp.mdx
+++ b/src/content/pages/cfp.mdx
@@ -11,7 +11,7 @@ It was running between
 **Wednesday, 14th February 2024** and **Wednesday, 13th, March 2024**
 [Anywhere on Earth](https://en.wikipedia.org/wiki/Anywhere_on_Earth)
 
-<ButtonLink>Form closed. Thank your for your participation and contribution! 🐍</ButtonLink>
+<Button>Form closed. Thank your for your participation and contribution! 🐍</Button>
 </div>
 ---
 

--- a/src/content/pages/tickets.mdx
+++ b/src/content/pages/tickets.mdx
@@ -127,4 +127,4 @@ keep in the know! -->
 */}
 
 ## How can I get a refund?
-We understand things can be complicated at times and you may not be able to attend after booking your ticket. Therefore, we aim to offer a full refund of your ticket(s) if your circumstances change. Before 17 June, you can request a full refund from the order details link in your order confirmation email. After the date, please email us at [refunds@europython.eu](mailto:refunds@europython.eu) if you need a refund due to special circumstances.
+We understand things can be complicated at times and you may not be able to attend after booking your ticket. Therefore, we aim to offer a full refund of your ticket(s) if your circumstances change. Before 8 June, you can request a full refund from the order details link in your order confirmation email. After the date, please email us at [refunds@europython.eu](mailto:refunds@europython.eu) if you need a refund due to special circumstances.


### PR DESCRIPTION
Updates:

* Updates the CfP page as the call has now ended. The page is updated according to the https://ep2023.europython.eu/cfp/ feel free to review!
* Updated the refund date from 17th to 8th, following the same changes with the late birds. (moved 9 days earlier as the conference is 9 days earlier than last year).