### PR TITLE
Fix sponsorship packages link and move brochure up

### DIFF
--- a/src/content/pages/sponsor.mdx
+++ b/src/content/pages/sponsor.mdx
@@ -23,6 +23,10 @@ further its development.
 
 <ButtonWithTitle title="Ready to become a sponsor and join us in Prague?" text="Sign Up Now!" href="https://docs.google.com/forms/d/1Ut6b5KaYtj1hAivVxMdaSfeNCUCNTrTq98o5v9uNg6I/" />
 
+<div class="text-center mt-4">
+<ButtonLink href="https://drive.google.com/file/d/17cZwOIIvC9g5PUPwn0WjFxilp0hNAJKI/view">Brochure EuroPython 2024 (PDF)</ButtonLink>
+</div>
+
 ## 2023 Stats & Demographics
 
 EuroPython 2023 was a hybrid conference, both in Prague & Online,
@@ -30,7 +34,6 @@ combining the good of both worlds.
 
 <div class="text-left [&>*]:mr-8 [&>*]:mb-2">
 <ButtonLink href="https://drive.google.com/file/d/19kjdiSNDpK1COz2qYgJKMGUfa5Wzft5c/view?usp=sharing">EuroPython 2023 Stats & Demographics (PDF)</ButtonLink>
-<ButtonLink href="https://drive.google.com/file/d/17cZwOIIvC9g5PUPwn0WjFxilp0hNAJKI/view">Brochure EuroPython 2024 (PDF)</ButtonLink>
 </div>
 
 ---
@@ -62,7 +65,7 @@ stand-alone sponsor options. Below are some examples:
 - And many more!
 
 <div class="text-left space-x-8">
-<ButtonLink href="https://drive.google.com/file/d/1r-sGUI55BNRd0K48ypgvJ8QFucnaMdrK/view?usp=sharing">Full list of Optional Extras (PDF)</ButtonLink>
+<ButtonLink href="https://drive.google.com/file/d/1KfqnSg-l1D5bUouj_jxMtqgugGpJ4rKQ/view">Full list of Optional Extras (PDF)</ButtonLink>
 <ButtonLink href="https://forms.gle/ieK9LwdoRyDU4Z9a7">Sign up now!</ButtonLink>
 </div>
 


### PR DESCRIPTION
1. Update the google drive link for "Full list of Optional Extras (PDF)" button that was not in the correct version
2. Move brochure at the "Ready to become a sponsor and join us in Prague?" section