### PR TITLE
PoC/WiP: create separate talks/tutorials/posters pages

### DIFF
--- a/src/content/pages/programme.mdx
+++ b/src/content/pages/programme.mdx
@@ -12,7 +12,7 @@ Welcome to the 23rd EuroPython. We’re the oldest and longest running volunteer
 A week of all things Python:
 
 * Monday & Tuesday, 8 & 9 July: Tutorials & Workshops
-* Wednesday–Friday, 10-12 July: Conference talks & sponsor exhibition
+* Wednesday–Friday, 10–12 July: Conference talks & sponsor exhibition
 * Saturday & Sunday, 13 & 14 July: Sprints
 
 

--- a/src/content/pages/programme.mdx
+++ b/src/content/pages/programme.mdx
@@ -1,7 +1,7 @@
 ---
 title: Programme
 subtitle:
-    Learn more about all the activites at EuroPython 2024
+    Check out all the activities at EuroPython 2024
 ---
 
 # Programme

--- a/src/content/pages/programme.mdx
+++ b/src/content/pages/programme.mdx
@@ -1,0 +1,51 @@
+---
+title: Programme
+subtitle:
+    Learn more about all the activites at EuroPython 2024
+---
+
+# Programme
+
+
+Welcome to the 23rd EuroPython. We’re the oldest and longest running volunteer-led Python programming conference on the planet! Join us in July in the vibrant Bohemian city Prague. We’ll be together, celebrating our shared passion for Python and its community!
+
+A week of all things Python:
+
+* Monday & Tuesday, 8 & 9 July: Tutorials & Workshops
+* Wednesday–Friday, 10-12 July: Conference talks & sponsor exhibition
+* Saturday & Sunday, 13 & 14 July: Sprints
+
+
+## Monday & Tuesday, 8 & 9 July
+
+First two days are dedicated to the Tutorials and Workshops.
+
+We start at 09:00am at the [PCC](/venue). On the first two days everything happens on the first floor only.
+
+We have [16 tutorials](/tutorials), two special workshops: [Django Girls](https://djangogirls.org/en/prague/) on Monday and [Humble Data](https://humbledata.org/) on Tuesday.
+
+Two Summits – [C-API Summit](/c-api-summit) on Monday, and [WASM Summit](/wasm-summit) on Tuesday.
+
+**Keep in mind that in order to attend the Tutorials you need a [Tutorial or Combined](/tickets/#ticket-types) ticket. Summits and workshops have a separate registration.**
+
+Spaces are limited so act fast :)
+
+If you are one of the speakers, we are also going to host a [Speaker's Dinner](/speakers-dinner) on Tuesday.
+
+## Wednesday–Friday, 10-12 July
+
+Right after the opening session on Wednesday, we start with first of the [6 Keynotes](/keynotes).
+
+Then for the next three days, you can enjoy [110 Talks](/talks) running in 6 parallel tracks, and [9 Posters](/posters) happening during lunch breaks in the expo area.
+
+All the main conference activities happen on those three days. On top of that you can visit our [Sponsor Exhibition](/sponsor), any of the other extra [Events](/events), including a [Social Event](/social-event) on Thursday.
+
+
+## Saturday & Sunday, 13 & 14 July
+
+For Saturday and Sunday we switch to a different venue, more suitable for [Sprints](/sprints).
+
+As per our tradition, the conference organisers will provide the rooms and
+facilities but the sprints are organised by YOU. It is a great chance to
+contribute to open-source projects large and small, learn from each other, geek
+out and have fun.

--- a/src/content/pages/programme.mdx
+++ b/src/content/pages/programme.mdx
@@ -26,7 +26,7 @@ We have [16 tutorials](/tutorials), two special workshops: [Django Girls](https:
 
 Two Summits – [C-API Summit](/c-api-summit) on Monday, and [WASM Summit](/wasm-summit) on Tuesday.
 
-**Keep in mind that in order to attend the Tutorials you need a [Tutorial or Combined](/tickets/#ticket-types) ticket. Summits and workshops have a separate registration.**
+**Keep in mind that in order to attend the Tutorials you need a [Tutorial or Combined](/tickets/#ticket-types) ticket. Summits and workshops require a separate registration.**
 
 Spaces are limited so act fast :)
 

--- a/src/content/pages/programme.mdx
+++ b/src/content/pages/programme.mdx
@@ -20,7 +20,7 @@ A week of all things Python:
 
 First two days are dedicated to the Tutorials and Workshops.
 
-We start at 09:00am at the [PCC](/venue). On the first two days everything happens on the first floor only.
+We start at 9:00 a.m. at the [PCC](/venue). On the first two days, all activities will take place on the first floor only.
 
 We have [16 tutorials](/tutorials), two special workshops: [Django Girls](https://djangogirls.org/en/prague/) on Monday and [Humble Data](https://humbledata.org/) on Tuesday.
 

--- a/src/content/pages/programme.mdx
+++ b/src/content/pages/programme.mdx
@@ -34,7 +34,7 @@ If you are a speaker, we are also hosting a [Speaker's Dinner](/speakers-dinner)
 
 ## Wednesday–Friday, 10-12 July
 
-Right after the opening session on Wednesday, we start with first of the [6 Keynotes](/keynotes).
+After the opening session on Wednesday, we will start with the first of the [6 Keynote talks](/keynotes).
 
 Then for the next three days, you can enjoy [110 Talks](/talks) running in 6 parallel tracks, and [9 Posters](/posters) happening during lunch breaks in the expo area.
 

--- a/src/content/pages/programme.mdx
+++ b/src/content/pages/programme.mdx
@@ -7,7 +7,7 @@ subtitle:
 # Programme
 
 
-Welcome to the 23rd EuroPython. We’re the oldest and longest running volunteer-led Python programming conference on the planet! Join us in July in the vibrant Bohemian city Prague. We’ll be together, celebrating our shared passion for Python and its community!
+Welcome to the 23rd EuroPython. We’re the oldest and longest-running volunteer-led Python programming conference on the planet! Join us in July in the vibrant Bohemian city of Prague. We’ll be together, celebrating our shared passion for Python and its community!
 
 A week of all things Python:
 

--- a/src/content/pages/programme.mdx
+++ b/src/content/pages/programme.mdx
@@ -28,7 +28,7 @@ Two Summits – [C-API Summit](/c-api-summit) on Monday, and [WASM Summit](/wasm
 
 **Keep in mind that in order to attend the Tutorials you need a [Tutorial or Combined](/tickets/#ticket-types) ticket. Summits and workshops require a separate registration.**
 
-Spaces are limited so act fast :)
+Spaces are limited, so act fast. :)
 
 If you are one of the speakers, we are also going to host a [Speaker's Dinner](/speakers-dinner) on Tuesday.
 

--- a/src/content/pages/programme.mdx
+++ b/src/content/pages/programme.mdx
@@ -43,9 +43,9 @@ All the main conference activities occur on those three days. On top of that, yo
 
 ## Saturday & Sunday, 13 & 14 July
 
-For Saturday and Sunday we switch to a different venue, more suitable for [Sprints](/sprints).
+For Saturday and Sunday, we will switch to a different venue, more suitable for [Sprints](/sprints).
 
 As per our tradition, the conference organisers will provide the rooms and
-facilities but the sprints are organised by YOU. It is a great chance to
+facilities, but the sprints are organised by YOU. It is a great chance to
 contribute to open-source projects large and small, learn from each other, geek
-out and have fun.
+out, and have fun.

--- a/src/content/pages/programme.mdx
+++ b/src/content/pages/programme.mdx
@@ -36,7 +36,7 @@ If you are a speaker, we are also hosting a [Speaker's Dinner](/speakers-dinner)
 
 After the opening session on Wednesday, we will start with the first of the [6 Keynote talks](/keynotes).
 
-Then for the next three days, you can enjoy [110 Talks](/talks) running in 6 parallel tracks, and [9 Posters](/posters) happening during lunch breaks in the expo area.
+Then, for the next three days, you can enjoy [110 Talks](/talks) running in 6 parallel tracks, and [9 Posters](/posters) presented during lunch breaks in the expo area.
 
 All the main conference activities happen on those three days. On top of that you can visit our [Sponsor Exhibition](/sponsor), any of the other extra [Events](/events), including a [Social Event](/social-event) on Thursday.
 

--- a/src/content/pages/programme.mdx
+++ b/src/content/pages/programme.mdx
@@ -30,7 +30,7 @@ Two Summits – [C-API Summit](/c-api-summit) on Monday, and [WASM Summit](/wasm
 
 Spaces are limited, so act fast. :)
 
-If you are one of the speakers, we are also going to host a [Speaker's Dinner](/speakers-dinner) on Tuesday.
+If you are a speaker, we are also hosting a [Speaker's Dinner](/speakers-dinner) on Tuesday.
 
 ## Wednesday–Friday, 10-12 July
 

--- a/src/content/pages/programme.mdx
+++ b/src/content/pages/programme.mdx
@@ -22,7 +22,7 @@ First two days are dedicated to the Tutorials and Workshops.
 
 We start at 9:00 a.m. at the [PCC](/venue). On the first two days, all activities will take place on the first floor only.
 
-We have [16 tutorials](/tutorials), two special workshops: [Django Girls](https://djangogirls.org/en/prague/) on Monday and [Humble Data](https://humbledata.org/) on Tuesday.
+We are hosting [16 tutorials](/tutorials), and two special beginner workshops: [Django Girls](https://djangogirls.org/en/prague/) on Monday and [Humble Data](https://humbledata.org/) on Tuesday.
 
 Two Summits – [C-API Summit](/c-api-summit) on Monday, and [WASM Summit](/wasm-summit) on Tuesday.
 

--- a/src/content/pages/programme.mdx
+++ b/src/content/pages/programme.mdx
@@ -38,7 +38,7 @@ After the opening session on Wednesday, we will start with the first of the [6 K
 
 Then, for the next three days, you can enjoy [110 Talks](/talks) running in 6 parallel tracks, and [9 Posters](/posters) presented during lunch breaks in the expo area.
 
-All the main conference activities happen on those three days. On top of that you can visit our [Sponsor Exhibition](/sponsor), any of the other extra [Events](/events), including a [Social Event](/social-event) on Thursday.
+All the main conference activities occur on those three days. On top of that, you can visit our [Sponsor Exhibition](/sponsor) and any of the other extra [Events](/events), including a [Social Event](/social-event) on Thursday.
 
 
 ## Saturday & Sunday, 13 & 14 July

--- a/src/data/links.json
+++ b/src/data/links.json
@@ -4,10 +4,6 @@
       "name": "Programme",
       "items": [
         {
-          "name": "Overview",
-          "path": "/programme"
-        },
-        {
           "name": "List of sessions",
           "path": "/sessions"
         },

--- a/src/data/links.json
+++ b/src/data/links.json
@@ -4,12 +4,24 @@
       "name": "Programme",
       "items": [
         {
-          "name": "Speaker Mentorship",
-          "path": "/mentorship"
+          "name": "Overview",
+          "path": "/programme"
         },
         {
           "name": "List of sessions",
           "path": "/sessions"
+        },
+        {
+          "name": "Talks",
+          "path": "/talks"
+        },
+        {
+          "name": "Tutorials",
+          "path": "/tutorials"
+        },
+        {
+          "name": "Posters",
+          "path": "/posters"
         },
         {
           "name": "Call for Proposals",
@@ -18,6 +30,10 @@
         {
           "name": "Community Voting",
           "path": "/voting"
+        },
+        {
+          "name": "Speaker Mentorship",
+          "path": "/mentorship"
         }
       ]
     },

--- a/src/pages/posters.astro
+++ b/src/pages/posters.astro
@@ -84,34 +84,3 @@ const description = "A list of all the sessions at the conference";
     </ol>
   </div>
 </Layout>
-
-<script>
-  const forms = document.querySelectorAll("form.filter-sessions");
-
-  forms.forEach((form) => {
-    form.querySelectorAll("select").forEach((select) => {
-      select.addEventListener("change", () => {
-        // @ts-ignore
-        const track = form.querySelector("#track").value;
-        // @ts-ignore
-        const type = form.querySelector("#type").value;
-
-        document.querySelectorAll("ol.sessions > li").forEach((session) => {
-          const sessionTrack = session.getAttribute("data-track");
-          const sessionType = session.getAttribute("data-type");
-
-          if (
-            (track === "" || sessionTrack === track) &&
-            (type === "" || sessionType === type)
-          ) {
-            // @ts-ignore
-            session.style.display = "block";
-          } else {
-            // @ts-ignore
-            session.style.display = "none";
-          }
-        });
-      });
-    });
-  });
-</script>

--- a/src/pages/posters.astro
+++ b/src/pages/posters.astro
@@ -8,6 +8,7 @@ import { Tag } from "../components/tag/tag";
 import SessionSpeakers from "../components/session-speakers.astro";
 
 const sessions = await getCollection("sessions");
+const posters = sessions.filter(s => s.data.submission_type === "Poster");
 
 const allTracks = Array.from(
   new Set(sessions.map((session) => session.data.track)),
@@ -17,7 +18,6 @@ const allTypes = Array.from(
   new Set(sessions.map((session) => session.data.submission_type)),
 ).sort();
 
-console.log(sessions[0]);
 const title = "Sessions";
 
 const description = "A list of all the sessions at the conference";
@@ -26,30 +26,24 @@ const description = "A list of all the sessions at the conference";
 <Layout title={title} description={description}>
   <div class="px-6">
     <Prose>
-      <h1>List of all confirmed sessions</h1>
+      <h1>Posters</h1>
 
-      <h2>Filters</h2>
+      <p>
+      During the lunch breaks, on Wednesday, Thursday and Friday we will host {posters.length} poster sessions. You can see them all below.
+      </p>
+
+      <p>
+      The Posters will be available throughout the entire event. If you want to talk to the author of the poster, please visit the expo area during the scheduled poster session.
+      </p>
+
+
+      <h2>List of posters</h2>
+
     </Prose>
-
-    <form class="mb-12 filter-sessions">
-      <div class="mb-6">
-        <Label htmlFor="track">Track</Label>
-        <Select id="track" name="track">
-          <option value="">All</option>
-          {allTracks.map((track) => <option value={track}>{track}</option>)}
-        </Select>
-      </div>
-
-      <Label htmlFor="type">Session type</Label>
-      <Select id="type" name="type">
-        <option value="">All</option>
-        {allTypes.map((type) => <option value={type}>{type}</option>)}
-      </Select>
-    </form>
 
     <ol class="sessions">
       {
-        sessions.map((session) => (
+        posters.map((session) => (
           <li
             class="mb-12"
             data-track={session.data.track}
@@ -70,22 +64,12 @@ const description = "A list of all the sessions at the conference";
             </Prose>
 
             <ul class="space-x-2 capitalize">
-
-              <li class="inline-block">
-                <Tag>
-                  <span class="sr-only">Type:</span>
-                  {session.data.submission_type}
-                </Tag>
-              </li>
-
-
               <li class="inline-block">
                 <Tag>
                   <span class="sr-only">Track:</span>
                   {session.data.track}
                 </Tag>
               </li>
-
 
               <li class="inline-block">
                 <Tag>

--- a/src/pages/posters.astro
+++ b/src/pages/posters.astro
@@ -29,7 +29,7 @@ const description = "A list of all the sessions at the conference";
       <h1>Posters</h1>
 
       <p>
-      During the lunch breaks, on Wednesday, Thursday and Friday we will host {posters.length} poster sessions. You can see them all below.
+      During the lunch breaks on Wednesday, Thursday and Friday, we will host {posters.length} poster sessions. You can see them all below.
       </p>
 
       <p>

--- a/src/pages/talks.astro
+++ b/src/pages/talks.astro
@@ -8,6 +8,7 @@ import { Tag } from "../components/tag/tag";
 import SessionSpeakers from "../components/session-speakers.astro";
 
 const sessions = await getCollection("sessions");
+const talks = sessions.filter(s => s.data.submission_type.substr(0,4) === "Talk");
 
 const allTracks = Array.from(
   new Set(sessions.map((session) => session.data.track)),
@@ -17,7 +18,6 @@ const allTypes = Array.from(
   new Set(sessions.map((session) => session.data.submission_type)),
 ).sort();
 
-console.log(sessions[0]);
 const title = "Sessions";
 
 const description = "A list of all the sessions at the conference";
@@ -26,30 +26,23 @@ const description = "A list of all the sessions at the conference";
 <Layout title={title} description={description}>
   <div class="px-6">
     <Prose>
-      <h1>List of all confirmed sessions</h1>
+      <h1>Talks</h1>
 
-      <h2>Filters</h2>
+      <p>
+      From Wednesday to Friday you can enjoy {talks.length} talks in 6 parallel tracks
+      </p>
+
+      <p>
+      Below there is a list of all proposals that were accepted from our <a href="/cfp">CFP</a>.
+      </p>
+
+      <h2>List of talks</h2>
+
     </Prose>
-
-    <form class="mb-12 filter-sessions">
-      <div class="mb-6">
-        <Label htmlFor="track">Track</Label>
-        <Select id="track" name="track">
-          <option value="">All</option>
-          {allTracks.map((track) => <option value={track}>{track}</option>)}
-        </Select>
-      </div>
-
-      <Label htmlFor="type">Session type</Label>
-      <Select id="type" name="type">
-        <option value="">All</option>
-        {allTypes.map((type) => <option value={type}>{type}</option>)}
-      </Select>
-    </form>
 
     <ol class="sessions">
       {
-        sessions.map((session) => (
+        talks.map((session) => (
           <li
             class="mb-12"
             data-track={session.data.track}
@@ -70,15 +63,6 @@ const description = "A list of all the sessions at the conference";
             </Prose>
 
             <ul class="space-x-2 capitalize">
-
-              <li class="inline-block">
-                <Tag>
-                  <span class="sr-only">Type:</span>
-                  {session.data.submission_type}
-                </Tag>
-              </li>
-
-
               <li class="inline-block">
                 <Tag>
                   <span class="sr-only">Track:</span>
@@ -86,6 +70,12 @@ const description = "A list of all the sessions at the conference";
                 </Tag>
               </li>
 
+              <li class="inline-block">
+                <Tag>
+                  <span class="sr-only">Type:</span>
+                  {session.data.submission_type}
+                </Tag>
+              </li>
 
               <li class="inline-block">
                 <Tag>

--- a/src/pages/talks.astro
+++ b/src/pages/talks.astro
@@ -72,13 +72,6 @@ const description = "A list of all the sessions at the conference";
 
               <li class="inline-block">
                 <Tag>
-                  <span class="sr-only">Type:</span>
-                  {session.data.submission_type}
-                </Tag>
-              </li>
-
-              <li class="inline-block">
-                <Tag>
                   <span class="sr-only">Level:</span>
                   {session.data.level}
                 </Tag>

--- a/src/pages/talks.astro
+++ b/src/pages/talks.astro
@@ -83,34 +83,3 @@ const description = "A list of all the sessions at the conference";
     </ol>
   </div>
 </Layout>
-
-<script>
-  const forms = document.querySelectorAll("form.filter-sessions");
-
-  forms.forEach((form) => {
-    form.querySelectorAll("select").forEach((select) => {
-      select.addEventListener("change", () => {
-        // @ts-ignore
-        const track = form.querySelector("#track").value;
-        // @ts-ignore
-        const type = form.querySelector("#type").value;
-
-        document.querySelectorAll("ol.sessions > li").forEach((session) => {
-          const sessionTrack = session.getAttribute("data-track");
-          const sessionType = session.getAttribute("data-type");
-
-          if (
-            (track === "" || sessionTrack === track) &&
-            (type === "" || sessionType === type)
-          ) {
-            // @ts-ignore
-            session.style.display = "block";
-          } else {
-            // @ts-ignore
-            session.style.display = "none";
-          }
-        });
-      });
-    });
-  });
-</script>

--- a/src/pages/tutorials.astro
+++ b/src/pages/tutorials.astro
@@ -33,7 +33,7 @@ const description = "A list of all the sessions at the conference";
       </p>
 
       <p>
-      Our Programme team selected 16 best proposals submitted through our CFP
+      Our Programme team selected 16 best proposals submitted through our CfP.
       </p>
 
       <p>

--- a/src/pages/tutorials.astro
+++ b/src/pages/tutorials.astro
@@ -95,34 +95,3 @@ const description = "A list of all the sessions at the conference";
     </ol>
   </div>
 </Layout>
-
-<script>
-  const forms = document.querySelectorAll("form.filter-sessions");
-
-  forms.forEach((form) => {
-    form.querySelectorAll("select").forEach((select) => {
-      select.addEventListener("change", () => {
-        // @ts-ignore
-        const track = form.querySelector("#track").value;
-        // @ts-ignore
-        const type = form.querySelector("#type").value;
-
-        document.querySelectorAll("ol.sessions > li").forEach((session) => {
-          const sessionTrack = session.getAttribute("data-track");
-          const sessionType = session.getAttribute("data-type");
-
-          if (
-            (track === "" || sessionTrack === track) &&
-            (type === "" || sessionType === type)
-          ) {
-            // @ts-ignore
-            session.style.display = "block";
-          } else {
-            // @ts-ignore
-            session.style.display = "none";
-          }
-        });
-      });
-    });
-  });
-</script>

--- a/src/pages/tutorials.astro
+++ b/src/pages/tutorials.astro
@@ -45,7 +45,7 @@ const description = "A list of all the sessions at the conference";
       <p>
       To attend a tutorial you need a separate <a href="/tickets#tutorial-tickets">Tutorial</a> or a <a href="/tickets#combined-tickets">Combined</a> ticket.
 
-      The access to each tutorial room is on a first come first served basis. Other than having a compatible ticket type, there is no other registration required
+      Access to each tutorial room is on a first-come, first-served basis. Other than having a compatible ticket type, no other registration is required.
       </p>
 
       <h2>List of tutorials</h2>

--- a/src/pages/tutorials.astro
+++ b/src/pages/tutorials.astro
@@ -8,6 +8,7 @@ import { Tag } from "../components/tag/tag";
 import SessionSpeakers from "../components/session-speakers.astro";
 
 const sessions = await getCollection("sessions");
+const tutorials = sessions.filter(s => s.data.submission_type === "Tutorial");
 
 const allTracks = Array.from(
   new Set(sessions.map((session) => session.data.track)),
@@ -17,7 +18,6 @@ const allTypes = Array.from(
   new Set(sessions.map((session) => session.data.submission_type)),
 ).sort();
 
-console.log(sessions[0]);
 const title = "Sessions";
 
 const description = "A list of all the sessions at the conference";
@@ -26,30 +26,35 @@ const description = "A list of all the sessions at the conference";
 <Layout title={title} description={description}>
   <div class="px-6">
     <Prose>
-      <h1>List of all confirmed sessions</h1>
+      <h1>Tutorials</h1>
 
-      <h2>Filters</h2>
+      <p>
+      First two days of EuroPython (Monday 8th, and Tuesday 9th of July) are dedicated to tutorials. Each Tutorial is a 3 hour long session, made up of two 90 minute segements, seprated by a short break.
+      </p>
+
+      <p>
+      Our Programme team selected 16 best proposals submitted through our CFP
+      </p>
+
+      <p>
+      Tutorials will happen in Club Rooms of the PCC, on the first floor.
+      If you have trouble finding the specific rooms, please check with the registration desk on the first floor.
+      </p>
+
+
+      <p>
+      To attend a tutorial you need a separate <a href="/tickets#tutorial-tickets">Tutorial</a> or a <a href="/tickets#combined-tickets">Combined</a> ticket.
+
+      The access to each tutorial room is on a first come first served basis. Other than having a compatible ticket type, there is no other registration required
+      </p>
+
+      <h2>List of tutorials</h2>
+
     </Prose>
-
-    <form class="mb-12 filter-sessions">
-      <div class="mb-6">
-        <Label htmlFor="track">Track</Label>
-        <Select id="track" name="track">
-          <option value="">All</option>
-          {allTracks.map((track) => <option value={track}>{track}</option>)}
-        </Select>
-      </div>
-
-      <Label htmlFor="type">Session type</Label>
-      <Select id="type" name="type">
-        <option value="">All</option>
-        {allTypes.map((type) => <option value={type}>{type}</option>)}
-      </Select>
-    </form>
 
     <ol class="sessions">
       {
-        sessions.map((session) => (
+        tutorials.map((session) => (
           <li
             class="mb-12"
             data-track={session.data.track}
@@ -70,15 +75,6 @@ const description = "A list of all the sessions at the conference";
             </Prose>
 
             <ul class="space-x-2 capitalize">
-
-              <li class="inline-block">
-                <Tag>
-                  <span class="sr-only">Type:</span>
-                  {session.data.submission_type}
-                </Tag>
-              </li>
-
-
               <li class="inline-block">
                 <Tag>
                   <span class="sr-only">Track:</span>
@@ -86,6 +82,12 @@ const description = "A list of all the sessions at the conference";
                 </Tag>
               </li>
 
+              <li class="inline-block">
+                <Tag>
+                  <span class="sr-only">Type:</span>
+                  {session.data.submission_type}
+                </Tag>
+              </li>
 
               <li class="inline-block">
                 <Tag>

--- a/src/pages/tutorials.astro
+++ b/src/pages/tutorials.astro
@@ -29,7 +29,7 @@ const description = "A list of all the sessions at the conference";
       <h1>Tutorials</h1>
 
       <p>
-      First two days of EuroPython (Monday 8th, and Tuesday 9th of July) are dedicated to tutorials. Each Tutorial is a 3 hour long session, made up of two 90 minute segements, seprated by a short break.
+      The first two days of EuroPython (Monday, July 8th, and Tuesday, July 9th) are dedicated to tutorials. Each Tutorial is a 3-hour long session, made up of two 90-minute segments, separated by a short break.
       </p>
 
       <p>

--- a/src/pages/tutorials.astro
+++ b/src/pages/tutorials.astro
@@ -84,13 +84,6 @@ const description = "A list of all the sessions at the conference";
 
               <li class="inline-block">
                 <Tag>
-                  <span class="sr-only">Type:</span>
-                  {session.data.submission_type}
-                </Tag>
-              </li>
-
-              <li class="inline-block">
-                <Tag>
                   <span class="sr-only">Level:</span>
                   {session.data.level}
                 </Tag>

--- a/src/pages/tutorials.astro
+++ b/src/pages/tutorials.astro
@@ -37,7 +37,7 @@ const description = "A list of all the sessions at the conference";
       </p>
 
       <p>
-      Tutorials will happen in Club Rooms of the PCC, on the first floor.
+      Tutorials will take place in Club Rooms of the PCC on the first floor.
       If you have trouble finding the specific rooms, please check with the registration desk on the first floor.
       </p>
 

--- a/src/pages/tutorials.astro
+++ b/src/pages/tutorials.astro
@@ -38,7 +38,7 @@ const description = "A list of all the sessions at the conference";
 
       <p>
       Tutorials will take place in Club Rooms of the PCC on the first floor.
-      If you have trouble finding the specific rooms, please check with the registration desk on the first floor.
+      If you have trouble finding specific rooms, please check with the registration desk on the first floor.
       </p>
 
 


### PR DESCRIPTION
This is a PoC of separate pages for the different types of sessions. Plus the overview of the whole Programme.
This is just meant to present an idea, and is not a final version. Both copy and the code will need updates before merging :)