### PR TITLE
Fix sourceless image tags

### DIFF
--- a/src/pages/session/[slug].astro
+++ b/src/pages/session/[slug].astro
@@ -2,7 +2,7 @@
 import { getCollection, getEntries } from "astro:content";
 import Layout from "../../layouts/Layout.astro";
 import Prose from "../../components/prose/prose.astro";
-import { Separator } from "../../components/separator/separator.tsx";
+import { Separator } from "../../components/separator/separator";
 
 export async function getStaticPaths() {
   const blogEntries = await getCollection("sessions");
@@ -60,13 +60,23 @@ for (const speaker of speakers) {
 
             {speakers.map((speaker) => (
               <div class="mb-4 md:grid grid-cols-[260px_1fr] md:gap-6">
-                <div class="flex items-start mb-4">
-                  <img
-                    src={speaker.data.avatar}
-                    alt={speaker.data.name}
-                    class="w-full max-w-sm mb-12"
-                  />
-                </div>
+                {speaker.data.avatar ? (
+                  <div class="flex items-start mb-4">
+                    <img
+                      src={speaker.data.avatar}
+                      alt={speaker.data.name}
+                      class="w-full max-w-sm mb-12"
+                    />
+                  </div>
+                ) : (
+                  <div class="flex items-start mb-4 invisible">
+                    <img
+                      src=""
+                      alt=""
+                      class="w-full max-w-sm mb-12"
+                    />
+                  </div>
+                )}
                 <div>
                   <p class="mb-4">
                     <a

--- a/src/pages/speaker/[slug].astro
+++ b/src/pages/speaker/[slug].astro
@@ -32,13 +32,15 @@ function normalizeTwitterHandle(handle: string, { onlyUsername = false } = {}) {
     >
       {entry.data.name}
     </h1>
-    <div>
-      <img
-        src={entry.data.avatar}
-        alt={entry.data.name}
-        class="w-full max-w-sm mb-12"
-      />
-    </div>
+    {entry.data.avatar && (
+      <div>
+        <img
+          src={entry.data.avatar}
+          alt={entry.data.name}
+          class="w-full max-w-sm mb-12"
+        />
+      </div>
+    )}
     <h2
       class="relative font-title text-primary font-bold mb-[0.6em] [&>a]:border-0 [&>a]:text-inherit text-5xl"
     >


### PR DESCRIPTION
Here is an example:

![image](https://github.com/EuroPython/website/assets/75242929/0a39c3b8-5019-4f0b-b329-69e9740176a9)

and

![image](https://github.com/EuroPython/website/assets/75242929/5e8798ff-6b02-4929-bcc9-0b408d24b154)


