### PR TITLE
C API summit: Fix typo in project name

### DIFF
--- a/src/content/pages/capi.mdx
+++ b/src/content/pages/capi.mdx
@@ -11,7 +11,7 @@ subtitle: A summit to bring together users (and interested people) of the C API 
 
 The C API has many different stakeholders, including but not limited to
 CPython core developers, maintainers of Python extensions, code generators
-(Cython, pybindy11, etc) and alternative API design (HPy).
+(Cython, pybind11, etc) and alternative API design (HPy).
 
 The main goal of this summit is to make sure that people from all these
 different projects can meet and discuss about the state of the C API, existing


### PR DESCRIPTION
It's [pybind11](https://pybind11.readthedocs.io/en/stable/index.html) :)