### PR TITLE
Suggestion/events order

### DIFF
--- a/package.json
+++ b/package.json
@@ -47,5 +47,6 @@
   },
   "prettier": {
     "proseWrap": "always"
-  }
+  },
+  "packageManager": "pnpm@9.3.0+sha512.ee7b93e0c2bd11409c6424f92b866f31d3ea1bef5fbe47d3c7500cdc3c9668833d2e55681ad66df5b640c61fa9dc25d546efa54d76d7f8bf54b13614ac293631"
 }

--- a/package.json
+++ b/package.json
@@ -47,6 +47,5 @@
   },
   "prettier": {
     "proseWrap": "always"
-  },
-  "packageManager": "pnpm@9.3.0+sha512.ee7b93e0c2bd11409c6424f92b866f31d3ea1bef5fbe47d3c7500cdc3c9668833d2e55681ad66df5b640c61fa9dc25d546efa54d76d7f8bf54b13614ac293631"
+  }
 }

--- a/src/data/links.json
+++ b/src/data/links.json
@@ -45,22 +45,25 @@
           "path": "https://djangogirls.org/en/prague/"
         },
         {
-          "name": "Speakers' Dinner",
-          "path": "/speakers-dinner"
+          "name": "C API Summit",
+          "path": "/capi"
         },
         {
-          "name": "PyLadies Events—Lunch, Workshops & Networking",
-          "path": "/pyladies-events"
+          "name": "Humble Data",
+          "path": "/humble-data"
         },
         {
           "name": "WebAssembly Summit",
           "path": "/wasm"
         },
         {
-          "name": "C API Summit",
-          "path": "/capi"
+          "name": "Speakers' Dinner",
+          "path": "/speakers-dinner"
         },
-        { "name": "Humble Data", "path": "/humble-data" }
+        {
+          "name": "PyLadies Events—Lunch, Workshops & Networking",
+          "path": "/pyladies-events"
+        }
       ]
     },
     {


### PR DESCRIPTION
Suggestion to order the events menu to follow some pattern so it is easier to navigate. Currently, the one I suggest is:
- Conference events by day, i.e. events that happen once, during the conference, such as workshop, summit, etc. 
- Social events by day, i.e. events that happen once outside of the main conference.
- Multiple events / events that span several days, such as the PyLdadies programme, hackathon, etc. 
This is just a suggestion and there could be many more sensible way to order this. 