### PR TITLE
Fix LinkedIn profile link for speaker

### DIFF
--- a/src/content/speakers/GV9BKJ.mdx
+++ b/src/content/speakers/GV9BKJ.mdx
@@ -4,7 +4,7 @@ avatar: https://program.europython.eu/media/avatars/prof_lCHNRNw.jpg
 code: GV9BKJ
 gitx: https://github.com/mRokita
 homepage: null
-linkedin_url: "https://linkedin.com/in/linkedin.com/in/micha\u0142-rokita"
+linkedin_url: "https://linkedin.com/in/micha\u0142-rokita"
 mastodon_url: null
 name: "Micha\u0142 Rokita"
 slug: michal-rokita


### PR DESCRIPTION
I was just going through the schedule to decide which talks to attend and noticed a broken link on https://ep2024.europython.eu/speaker/michal-rokita to the LinkedIn profile of the speaker.

Not sure this way is how you want such suggestions and fixes to be reported, but I thought I'd give it a go as quick and easy option  without creating an issue or writing an email to the organiser.