### PR TITLE
Multiday events belong to the end.

### DIFF
--- a/src/data/links.json
+++ b/src/data/links.json
@@ -45,10 +45,6 @@
       "name": "Events",
       "items": [
         {
-          "name": "Sprint Weekend",
-          "path": "/sprints"
-        },
-        {
           "name": "Django Girls Workshop",
           "path": "https://djangogirls.org/en/prague/"
         },
@@ -83,6 +79,10 @@
         {
           "name": "Thursday Social Event",
           "path": "/social-event"
+        },
+        {
+          "name": "Sprint Weekend",
+          "path": "/sprints"
         }
       ]
     },


### PR DESCRIPTION
Link to sprints was at the beginning of the events tab. But belongs to the end.