### PR TITLE
sprints: fix link to sprints page source

### DIFF
--- a/src/content/pages/sprints.mdx
+++ b/src/content/pages/sprints.mdx
@@ -116,7 +116,7 @@ of participants.
 
 If you are planning to run a sprint at EuroPython 2024, please add it at the
 bottom of this page
-[creating a pull request to our website](https://github.com/EuroPython/website/src/content/pages/sprints.mdx):
+[creating a pull request to our website](https://github.com/EuroPython/website/blob/main/src/content/pages/sprints.mdx):
 
 1. Make sure your sprint is about an _open source_ project.
 2. Copy the template at the bottom of the sprint list.


### PR DESCRIPTION
Currently getting a 404