### PR TITLE
A11y: fix red button contrast

### DIFF
--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -6,7 +6,7 @@
   --color-primary: #0409e7;
   --color-primary-hover: #3c3ffa;
   --color-primary-active: #3c3ffa;
-  --color-button: #f00;
+  --color-button: #e00;
   --color-button-hover: #c00;
   --color-secondary: #ff8b9d;
   --color-secondary-dark: #203c90;


### PR DESCRIPTION
For https://github.com/EuroPython/website/issues/682.

The WCAG AA min contrast ratio is 4.5.

# Before

contrast ratio: 3.99:1 https://webaim.org/resources/contrastchecker/?fcolor=FFFFFF&bcolor=FF0000

![image](https://github.com/EuroPython/website/assets/1324225/8a7c7bd7-f724-46aa-8757-c5da45c2dd15)

# After

contrast ratio: 4.53:1 https://webaim.org/resources/contrastchecker/?fcolor=FFFFFF&bcolor=EE0000

![image](https://github.com/EuroPython/website/assets/1324225/1903bd3c-df32-4f61-aaab-e9fad917fd2b)

