### PR TITLE
A11y: fix card button contrast

### DIFF
--- a/src/components/card/card.astro
+++ b/src/components/card/card.astro
@@ -25,7 +25,7 @@ const { title, subtitle, url, image } = Astro.props;
   </div>
   <h3 class="text-3xl font-bold mt-6 mb-4 text-primary">{title}</h3>
   <p
-    class="bg-secondary inline-block text-text-inverted font-extrabold px-4 py-2 text-lg mb-4 rounded-[30px]"
+    class="bg-button inline-block text-text-inverted font-extrabold px-4 py-2 text-lg mb-4 rounded-[30px]"
   >
     {subtitle}
   </p>

--- a/src/components/card/card.astro
+++ b/src/components/card/card.astro
@@ -25,7 +25,7 @@ const { title, subtitle, url, image } = Astro.props;
   </div>
   <h3 class="text-3xl font-bold mt-6 mb-4 text-primary">{title}</h3>
   <p
-    class="bg-button inline-block text-text-inverted font-extrabold px-4 py-2 text-lg mb-4 rounded-[30px]"
+    class="bg-[#e22558] inline-block text-text-inverted font-extrabold px-4 py-2 text-lg mb-4 rounded-[30px]"
   >
     {subtitle}
   </p>


### PR DESCRIPTION
For https://github.com/EuroPython/website/issues/682.

# Before

The contrast ratio of white on pink is too low: 2.22: 1

![image](https://github.com/EuroPython/website/assets/1324225/96018656-bf95-497e-8007-2ccc74c98329)


# After

Instead of white on pink, use white on read, like the other buttons on the front page. With https://github.com/EuroPython/website/pull/773, the ratio will be 4.53:1, above the WCAG AA minimum of 4.5.

![image](https://github.com/EuroPython/website/assets/1324225/0848febf-ed2c-48bb-8880-52bcfc5f81d6)
