### PR TITLE
A11y: use black for schedule header to fix contrast

### DIFF
--- a/src/components/schedule/session.astro
+++ b/src/components/schedule/session.astro
@@ -197,6 +197,7 @@ const hasFooter = hasRoom || hasSpeakers;
   header {
     background-color: var(--color-primary);
     border-bottom: 2px solid var(--color-primary);
+    color: black;
     text-transform: capitalize;
     font-size: 0.8em;
   }


### PR DESCRIPTION
For https://github.com/EuroPython/website/issues/682.

# Before

Use primary colour (dark blue #0409e7) for schedule table headers. The ratio on the advanced #D34847 background is 2.17:1: https://webaim.org/resources/contrastchecker/?fcolor=000000&bcolor=D34847

![image](https://github.com/EuroPython/website/assets/1324225/dd894117-47b9-4b7c-a253-7ed2cd84e65d)


# After

Use black as the foreground colour. The ratio on the advanced #D34847 background is 4.78:1 https://webaim.org/resources/contrastchecker/?fcolor=FFFFFF&bcolor=FF0000

The other levels all remain above the WCAG AA min of 4.5:1.

![image](https://github.com/EuroPython/website/assets/1324225/0c67fdcd-c41a-4193-b27f-4babbfd9de8e)

