### PR TITLE
Include day name in session date

### DIFF
--- a/src/pages/session/[slug].astro
+++ b/src/pages/session/[slug].astro
@@ -65,7 +65,7 @@ for (const speaker of speakers) {
               {formatInTimeZone(
                 entry.data.start,
                 "Europe/Prague",
-                "HH:mm 'on' dd MMMM yyyy",
+                "HH:mm 'on' EEEE dd MMMM yyyy",
               )}
             </dd>
           </>


### PR DESCRIPTION
# Before

![image](https://github.com/EuroPython/website/assets/1324225/684b9e06-4ab1-42b4-a9e2-e448c02db82a)

I've no idea which day of the conference the 12th is, I don't want to have to always cross-reference with a calendar. Don't make me leave the EuroPython site.

# After

![image](https://github.com/EuroPython/website/assets/1324225/0855e16b-81f6-418b-bc90-0e991e044eef)

I know the main conference is Wednesday–Friday, it's much more useful to give the session's day name, for example Friday.