### PR TITLE
Update sprints page

### DIFF
--- a/src/content/pages/sprints.mdx
+++ b/src/content/pages/sprints.mdx
@@ -16,7 +16,7 @@ import vseImage2 from "./images/vse2.jpg";
 # EuroPython 2024 Sprints
 
 EuroPython 2024 Sprints will be during the weekend 13-14 July. This year, we are
-hosting the sprint weekend at a **different venue** and it will be free for
+hosting the sprint weekend at a **different venue** from the main conference and it will be free for
 anyone to join!
 
 As per our tradition, the conference organisers will provide the rooms and
@@ -115,7 +115,7 @@ of participants.
 - RB 109; occupancy: 0/48
 
 If you are planning to run a sprint at EuroPython 2024, please add it at the
-bottom of this page
+bottom of this page by
 [creating a pull request to our website](https://github.com/EuroPython/website/blob/main/src/content/pages/sprints.mdx):
 
 1. Make sure your sprint is about an _open source_ project.
@@ -145,9 +145,9 @@ and tag us @EuroPython ([twitter](https://twitter.com/europython),
 
 Please add your sprint here!
 
-### Organise Europython 2049 (copy this example template for your project)
-- Number of people: 10 (8 contributors + 2 organisers)
+### Project name (copy this example template for your project)
+- Number of people: x (y contributors + z organisers)
 - Room: RB 000
-- Python Level: any
-- Contact person: Foo Bar
+- Python Level: ???
+- Contact person: Foo Bar (foobar@example.com)
 - Links: https://github.com/EuroPython


### PR DESCRIPTION
Tiny improvements.

The page also says that registration will open “soon” for people who don't have a conference ticket but the linked page (`/tickets`) doesn't have information about that yet.