### PR TITLE
Fix the footer link to point to the 2024 photos instead of 2023

### DIFF
--- a/src/data/links.json
+++ b/src/data/links.json
@@ -182,8 +182,8 @@
   ],
   "footer": [
     {
-      "name": "2023 Photos",
-      "path": "https://ep2023.europython.eu/photos"
+      "name": "2024 Photos",
+      "path": "https://ep2024.europython.eu/photos"
     },
     {
       "name": "Contacts",


### PR DESCRIPTION
The current footer still points to the 2023 photos instead of the 2024 photos we have now.