### PR TITLE
Updates to the timeline in the FAQ so that it contains milestones up to today.

### DIFF
--- a/src/content/pages/faq.mdx
+++ b/src/content/pages/faq.mdx
@@ -26,7 +26,7 @@ subtitle: Frequently Asked Questions about EuroPython
 <li><b>2024-07-08</b>: Together at EuroPython 2024! 🎊 </li>
   <li><b>2024-07-13</b>: Sprint Weekend (13-14 July)</li>
   <li><b>2024-07-14</b>: End of EuroPython 2024</li>
-  <li><b>2024-09-13</b>:  Celebrate the [Team of Europython 2024 ](/thank-you)</li>
+  <li><b>2024-09-13</b>:  Celebrate the [Team of EuroPython 2024 ](/thank-you)</li>
   <li><b>2024-09-16</b>: [EuroPython 2024 Photos](/photos) Published</li>
   <li><b>2024-10-03</b>: [EuroPython 2024 Videos](https://www.youtube.com/playlist?list=PL8uoeex94UhE1CbtkDK4hevp2lBif57Nq) Published</li>
   </ul>

--- a/src/content/pages/faq.mdx
+++ b/src/content/pages/faq.mdx
@@ -23,11 +23,20 @@ subtitle: Frequently Asked Questions about EuroPython
 <li><b>2024-06-11</b>: [Schedule](/schedule) published</li>
 <li><b>2024-06-14</b>: [Remote Ticket Sales](/tickets#remote-tickets) & [Financial Aid for Remote Participation](/finaid#-free-remote-ticket) start</li>
 <li><b>2024-06-30</b>: [Sprints Venue & Info](/sprints) announced</li>
-</ul>
-
-<ul className="milestone-todo">
 <li><b>2024-07-08</b>: Together at EuroPython 2024! 🎊 </li>
-</ul>
+  <li><b>2024-07-13</b>: Sprint Weekend (13-14 July)</li>
+  <li><b>2024-07-14</b>: End of EuroPython 2024</li>
+  <li><b>2024-09-13</b>:  Celebrate the [Team of Europython 2024 ](/thank-you)</li>
+  <li><b>2024-09-16</b>: [EuroPython 2024 Photos](/photos) Published</li>
+  <li><b>2024-08-03</b>: [EuroPython 2024 Videos](https://www.youtube.com/playlist?list=PL8uoeex94UhE1CbtkDK4hevp2lBif57Nq) Published</li>
+  </ul>
+
+[//]: # ()
+[//]: # (<ul className="milestone-todo">)
+
+[//]: # (<li><b>2024-12-01</b>: Let's get ready for EuroPython 2025! 🎊 </li>)
+
+[//]: # (</ul>)
 
 ## **Q. When and where is EuroPython 2024 taking place?**
 

--- a/src/content/pages/faq.mdx
+++ b/src/content/pages/faq.mdx
@@ -28,7 +28,7 @@ subtitle: Frequently Asked Questions about EuroPython
   <li><b>2024-07-14</b>: End of EuroPython 2024</li>
   <li><b>2024-09-13</b>:  Celebrate the [Team of Europython 2024 ](/thank-you)</li>
   <li><b>2024-09-16</b>: [EuroPython 2024 Photos](/photos) Published</li>
-  <li><b>2024-08-03</b>: [EuroPython 2024 Videos](https://www.youtube.com/playlist?list=PL8uoeex94UhE1CbtkDK4hevp2lBif57Nq) Published</li>
+  <li><b>2024-10-03</b>: [EuroPython 2024 Videos](https://www.youtube.com/playlist?list=PL8uoeex94UhE1CbtkDK4hevp2lBif57Nq) Published</li>
   </ul>
 
 [//]: # ()


### PR DESCRIPTION
The Timeline in the faq was lagging behind by a lot. This should be fixed now.