### PR TITLE
Add WASM Summit

### DIFF
--- a/src/content/pages/programme/wasm-summit.mdx
+++ b/src/content/pages/programme/wasm-summit.mdx
@@ -1,0 +1,35 @@
+---
+title: WebAssembly Summit
+subtitle: A summit to bring together maintainers and users of Python with WebAssembly, to discuss the state of this ecosystem, existing challenges, and ongoing work.
+---
+
+# WebAssembly Summit
+
+* **When**: Monday, July 14th or Tuesday, July 15th (to be confirmed)
+* **Where**: Prague Congress Centre (PCC), Room to be announced
+* **Who can join**: Anyone with a valid in-person EuroPython 2025 ticket
+
+
+This summit aims to bring together maintainers and users of Python with WebAssembly, to discuss the state of this ecosystem, existing challenges, and ongoing work.
+
+
+## Agenda
+
+* 9:00: Meet and greet (many of us won’t know each other) + unconference-y post-it based organisation.
+* 9:30: Presentations (30mins each)
+* 11:00: Coffee
+* 11:15: Presentations
+* 12:45: Lunch at the PCC (included)
+* 13:45: Unconference-y activities (discussions, hacks, ad hoc tutorials etc…)
+* 16:00: Round-up / plenary session for feedback and organising next steps.
+* 18:30-ish: Ad hoc dinner plans.
+
+## Registration
+
+You need to have a valid EuroPython in-person ticket to participate.
+
+The event is limited to 40 participants. If there is a topic you would like to present, please indicate it in the form and _fill it in early_. Time slots are of 30min at most (10 min of presentation + 20 min for questions/discussion).
+
+To be part of the WASM summit, [register your interest now!](https://forms.gle/aMtRA4D7qJ12i9aB8)
+
+We will contact you with more details closer to the event.

--- a/src/data/links.json
+++ b/src/data/links.json
@@ -1,69 +1,73 @@
 {
-  "header": [
-    {
-      "name": "Programme",
-      "items": [
+    "header": [
         {
-          "name": "Tracks",
-          "path": "/programme/tracks"
+            "name": "Programme",
+            "items": [
+                {
+                    "name": "Tracks",
+                    "path": "/programme/tracks"
+                },
+                {
+                    "name": "Selection Process",
+                    "path": "/programme/selection"
+                },
+                {
+                    "name": "Community Voting",
+                    "path": "/programme/voting"
+                },
+                {
+                    "name": "Speaker Mentorship",
+                    "path": "/programme/mentorship"
+                },
+                {
+                    "name": "C API Summit",
+                    "path": "/programme/c-api-summit"
+                },
+                {
+                    "name": "WebAssembly Summit",
+                    "path": "/programme/wasm-summit"
+                }
+            ]
         },
         {
-          "name": "Selection Process",
-          "path": "/programme/selection"
+            "name": "Prague & Venue",
+            "items": [
+                {
+                    "name": "Around Prague & PCC",
+                    "path": "/where"
+                },
+                {
+                    "name": "Exploring Prague",
+                    "path": "/explore"
+                }
+            ]
         },
         {
-          "name": "Community Voting",
-          "path": "/programme/voting"
-        },
-        {
-          "name": "Speaker Mentorship",
-          "path": "/programme/mentorship"
-        },
-        {
-          "name": "C API Summit",
-          "path": "/programme/c-api-summit"
+            "name": "Info & Support",
+            "items": [
+                {
+                    "name": "FAQ",
+                    "path": "/faq"
+                }
+            ]
         }
-      ]
-    },
-    {
-      "name": "Prague & Venue",
-      "items": [
+    ],
+    "footer": [
         {
-          "name": "Around Prague & PCC",
-          "path": "/where"
+            "name": "2024 Photos",
+            "path": "https://ep2024.europython.eu/photos"
         },
         {
-          "name": "Exploring Prague",
-          "path": "/explore"
-        }
-      ]
-    },
-    {
-      "name": "Info & Support",
-      "items": [
+            "name": "Contacts",
+            "path": "/contacts"
+        },
         {
-          "name": "FAQ",
-          "path": "/faq"
+            "name": "Terms",
+            "path": "/terms"
+        },
+        {
+            "name": "Privacy Policy",
+            "path": "https://www.europython-society.org/privacy/"
         }
-      ]
-    }
-  ],
-  "footer": [
-    {
-      "name": "2024 Photos",
-      "path": "https://ep2024.europython.eu/photos"
-    },
-    {
-      "name": "Contacts",
-      "path": "/contacts"
-    },
-    {
-      "name": "Terms",
-      "path": "/terms"
-    },
-    {
-      "name": "Privacy Policy",
-      "path": "https://www.europython-society.org/privacy/"
-    }
-  ]
+    ]
 }

--- a/src/data/links.json
+++ b/src/data/links.json
@@ -1,73 +1,73 @@
 {
-    "header": [
+  "header": [
+    {
+      "name": "Programme",
+      "items": [
         {
-            "name": "Programme",
-            "items": [
-                {
-                    "name": "Tracks",
-                    "path": "/programme/tracks"
-                },
-                {
-                    "name": "Selection Process",
-                    "path": "/programme/selection"
-                },
-                {
-                    "name": "Community Voting",
-                    "path": "/programme/voting"
-                },
-                {
-                    "name": "Speaker Mentorship",
-                    "path": "/programme/mentorship"
-                },
-                {
-                    "name": "C API Summit",
-                    "path": "/programme/c-api-summit"
-                },
-                {
-                    "name": "WebAssembly Summit",
-                    "path": "/programme/wasm-summit"
-                }
-            ]
+          "name": "Tracks",
+          "path": "/programme/tracks"
         },
         {
-            "name": "Prague & Venue",
-            "items": [
-                {
-                    "name": "Around Prague & PCC",
-                    "path": "/where"
-                },
-                {
-                    "name": "Exploring Prague",
-                    "path": "/explore"
-                }
-            ]
+          "name": "Selection Process",
+          "path": "/programme/selection"
         },
         {
-            "name": "Info & Support",
-            "items": [
-                {
-                    "name": "FAQ",
-                    "path": "/faq"
-                }
-            ]
+          "name": "Community Voting",
+          "path": "/programme/voting"
+        },
+        {
+          "name": "Speaker Mentorship",
+          "path": "/programme/mentorship"
+        },
+        {
+          "name": "C API Summit",
+          "path": "/programme/c-api-summit"
+        },
+        {
+          "name": "WebAssembly Summit",
+          "path": "/programme/wasm-summit"
         }
-    ],
-    "footer": [
+      ]
+    },
+    {
+      "name": "Prague & Venue",
+      "items": [
         {
-            "name": "2024 Photos",
-            "path": "https://ep2024.europython.eu/photos"
+          "name": "Around Prague & PCC",
+          "path": "/where"
         },
         {
-            "name": "Contacts",
-            "path": "/contacts"
-        },
-        {
-            "name": "Terms",
-            "path": "/terms"
-        },
-        {
-            "name": "Privacy Policy",
-            "path": "https://www.europython-society.org/privacy/"
+          "name": "Exploring Prague",
+          "path": "/explore"
         }
-    ]
+      ]
+    },
+    {
+      "name": "Info & Support",
+      "items": [
+        {
+          "name": "FAQ",
+          "path": "/faq"
+        }
+      ]
+    }
+  ],
+  "footer": [
+    {
+      "name": "2024 Photos",
+      "path": "https://ep2024.europython.eu/photos"
+    },
+    {
+      "name": "Contacts",
+      "path": "/contacts"
+    },
+    {
+      "name": "Terms",
+      "path": "/terms"
+    },
+    {
+      "name": "Privacy Policy",
+      "path": "https://www.europython-society.org/privacy/"
+    }
+  ]
 }

--- a/src/pages/wasm-summit.astro
+++ b/src/pages/wasm-summit.astro
@@ -1,0 +1,7 @@
+<script>
+    window.location.href = "/programme/wasm-summit/";
+</script>
+
+<noscript>
+    <meta http-equiv="refresh" content="0;url=https://ep2025.europython.eu/programme/wasm-summit/">
+</noscript>


### PR DESCRIPTION
Based off of #995 and #623.

The WASM page from last year linked to ticket info but we don't have that page up yet, correct?

@ntoll : as agreed, I copied the info from last year. Could you please take a look at this page/the preview and make sure everything looks alright? 🙏 