### PR TITLE
Add static search

### DIFF
--- a/astro.config.mjs
+++ b/astro.config.mjs
@@ -8,6 +8,7 @@ import remarkToc from "remark-toc";
 import rehypeSlug from "rehype-slug";
 import rehypeAutolinkHeadings from "rehype-autolink-headings";
 import metaTags from "astro-meta-tags";
+import pagefind from "astro-pagefind";
 
 // https://astro.build/config
 export default defineConfig({
@@ -42,6 +43,7 @@ export default defineConfig({
       nesting: true,
     }),
     metaTags(),
+    pagefind(),
   ],
   output: "static",
 });

--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "scripts": {
     "dev": "astro dev",
     "start": "astro dev",
-    "build": "astro check && astro build",
+    "build": "astro check && astro build && pnpm pagefind --site dist",
     "preview": "astro preview",
     "astro": "astro",
     "format": "prettier --write --plugin=prettier-plugin-astro ."
@@ -23,6 +23,7 @@
     "@types/react-dom": "^19.0.4",
     "astro": "^5.1.6",
     "astro-meta-tags": "^0.3.1",
+    "astro-pagefind": "^1.8.1",
     "clsx": "^2.1.1",
     "date-fns": "^4.1.0",
     "date-fns-tz": "^3.2.0",

--- a/pagefind.yml
+++ b/pagefind.yml
@@ -1,0 +1,2 @@
+site: dist
+glob: "**/*.{html}"

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -44,6 +44,9 @@ importers:
       astro-meta-tags:
         specifier: ^0.3.1
         version: 0.3.1(astro@5.5.2(jiti@1.21.7)(rollup@4.35.0)(typescript@5.8.2)(yaml@2.7.0))
+      astro-pagefind:
+        specifier: ^1.8.1
+        version: 1.8.3(astro@5.5.2(jiti@1.21.7)(rollup@4.35.0)(typescript@5.8.2)(yaml@2.7.0))
       clsx:
         specifier: ^2.1.1
         version: 2.1.1
@@ -566,9 +569,40 @@ packages:
   '@oslojs/encoding@1.1.0':
     resolution: {integrity: sha512-70wQhgYmndg4GCPxPPxPGevRKqTIJ2Nh4OkiMWmDAVYsTQ+Ta7Sq+rPevXyXGdzr30/qZBnyOalCszoMxlyldQ==}
 
+  '@pagefind/darwin-arm64@1.3.0':
+    resolution: {integrity: sha512-365BEGl6ChOsauRjyVpBjXybflXAOvoMROw3TucAROHIcdBvXk9/2AmEvGFU0r75+vdQI4LJdJdpH4Y6Yqaj4A==}
+    cpu: [arm64]
+    os: [darwin]
+
+  '@pagefind/darwin-x64@1.3.0':
+    resolution: {integrity: sha512-zlGHA23uuXmS8z3XxEGmbHpWDxXfPZ47QS06tGUq0HDcZjXjXHeLG+cboOy828QIV5FXsm9MjfkP5e4ZNbOkow==}
+    cpu: [x64]
+    os: [darwin]
+
+  '@pagefind/default-ui@1.3.0':
+    resolution: {integrity: sha512-CGKT9ccd3+oRK6STXGgfH+m0DbOKayX6QGlq38TfE1ZfUcPc5+ulTuzDbZUnMo+bubsEOIypm4Pl2iEyzZ1cNg==}
+
+  '@pagefind/linux-arm64@1.3.0':
+    resolution: {integrity: sha512-8lsxNAiBRUk72JvetSBXs4WRpYrQrVJXjlRRnOL6UCdBN9Nlsz0t7hWstRk36+JqHpGWOKYiuHLzGYqYAqoOnQ==}
+    cpu: [arm64]
+    os: [linux]
+
+  '@pagefind/linux-x64@1.3.0':
+    resolution: {integrity: sha512-hAvqdPJv7A20Ucb6FQGE6jhjqy+vZ6pf+s2tFMNtMBG+fzcdc91uTw7aP/1Vo5plD0dAOHwdxfkyw0ugal4kcQ==}
+    cpu: [x64]
+    os: [linux]
+
+  '@pagefind/windows-x64@1.3.0':
+    resolution: {integrity: sha512-BR1bIRWOMqkf8IoU576YDhij1Wd/Zf2kX/kCI0b2qzCKC8wcc2GQJaaRMCpzvCCrmliO4vtJ6RITp/AnoYUUmQ==}
+    cpu: [x64]
+    os: [win32]
+
   '@pkgjs/parseargs@0.11.0':
     resolution: {integrity: sha512-+1VkjdD0QBLPodGrJUeqarH8VAIvQODIbwh9XpP5Syisf7YoQgsJKPNFoqqLQlu+VQ/tVSshMR6loPMn8U+dPg==}
     engines: {node: '>=14'}
+
+  '@polka/url@1.0.0-next.28':
+    resolution: {integrity: sha512-8LduaNlMZGwdZ6qWrKlfa+2M4gahzFkprZiAt2TF8uS0qQgBizKXpXURqvTJ4WtmupWxaLqjRb2UCTe72mu+Aw==}
 
   '@rollup/pluginutils@5.1.4':
     resolution: {integrity: sha512-USm05zrsFxYLPdWWq+K3STlWiT/3ELn3RcV5hJMghpeAIhxfsUIg6mt12CBJBInWMV4VneoV7SfGv8xIwo2qNQ==}
@@ -860,6 +894,11 @@ packages:
     resolution: {integrity: sha512-6g/SfAVTV7BsGlfWU+s/Kvo6atyn9DpfI7Dq3fE/ck3ppfg30aoeT2Uxu7UH4yla3QXAUWaJIher7fGjewf0ew==}
     peerDependencies:
       astro: ^4.0.0 || ^5.0.0-beta.0
+
+  astro-pagefind@1.8.3:
+    resolution: {integrity: sha512-Nfo1TdlEHdkXTiI0KpimLqX6awK3qWTil7IOJvk5Q8x+0VBTpIEp9QvGgoAxXDe3upAHLVsg4y7U1uUPm7GC9w==}
+    peerDependencies:
+      astro: ^2.0.4 || ^3 || ^4 || ^5
 
   astro@5.5.2:
     resolution: {integrity: sha512-SOTJxB8mqxe/KEYEJiLIot0YULiCffyfTEclwmdeaASitDJ7eLM/KYrJ9sx3U5hq9GVI17Z4Y0P/1T2aQ0ZN3A==}
@@ -1683,6 +1722,10 @@ packages:
   package-manager-detector@1.0.0:
     resolution: {integrity: sha512-7elnH+9zMsRo7aS72w6MeRugTpdRvInmEB4Kmm9BVvPw/SLG8gXUGQ+4wF0Mys0RSWPz0B9nuBbDe8vFeA2sfg==}
 
+  pagefind@1.3.0:
+    resolution: {integrity: sha512-8KPLGT5g9s+olKMRTU9LFekLizkVIu9tes90O1/aigJ0T5LmyPqTzGJrETnSw3meSYg58YH7JTzhTTW/3z6VAw==}
+    hasBin: true
+
   parse-entities@4.0.2:
     resolution: {integrity: sha512-GG2AQYWoLgL877gQIKeRPGO1xF9+eG1ujIb5soS5gPvLQ1y2o8FL90w2QWNdf9I361Mpp7726c+lj3U0qK1uGw==}
 
@@ -1978,6 +2021,10 @@ packages:
   simple-swizzle@0.2.2:
     resolution: {integrity: sha512-JA//kQgZtbuY83m+xT+tXJkmJncGMTFT+C+g2h2R9uxkYIrE2yy9sgmcLhCnw57/WSD+Eh3J97FPEDFnbXnDUg==}
 
+  sirv@3.0.1:
+    resolution: {integrity: sha512-FoqMu0NCGBLCcAkS1qA+XJIQTR6/JHfQXl+uGteNCQ76T91DMUjPa9xfmeqMY3z80nLSg9yQmNjK0Px6RWsH/A==}
+    engines: {node: '>=18'}
+
   sisteransi@1.0.5:
     resolution: {integrity: sha512-bLGGlR1QxBcynn2d5YmDX4MGjlZvy2MRBDRNHLJ8VI6l6+9FUiyTFNJ0IveOSP0bcXgVDPRcfGqA0pjaqUpfVg==}
 
@@ -2067,6 +2114,10 @@ packages:
   to-regex-range@5.0.1:
     resolution: {integrity: sha512-65P7iz6X5yEr1cwcgvQxbbIw7Uk3gOy5dIdtZ4rDveLqhrdJP+Li/Hx6tyK0NEb+2GCyneCMJiGqrADCSNk8sQ==}
     engines: {node: '>=8.0'}
+
+  totalist@3.0.1:
+    resolution: {integrity: sha512-sf4i37nQ2LBx4m3wB74y+ubopq6W/dIzXg0FDGjsYnZHVa1Da8FH853wlL2gtUhg+xJXjfk3kUZS3BRoQeoQBQ==}
+    engines: {node: '>=6'}
 
   trim-lines@3.0.1:
     resolution: {integrity: sha512-kRj8B+YHZCc9kQYdWfJB2/oUl9rA99qbowYYBtr4ui4mZyAQ2JpvVBd/6U2YloATfqBhBTSMhTpgBHtU0Mf3Rg==}
@@ -2985,8 +3036,27 @@ snapshots:
 
   '@oslojs/encoding@1.1.0': {}
 
+  '@pagefind/darwin-arm64@1.3.0':
+    optional: true
+
+  '@pagefind/darwin-x64@1.3.0':
+    optional: true
+
+  '@pagefind/default-ui@1.3.0': {}
+
+  '@pagefind/linux-arm64@1.3.0':
+    optional: true
+
+  '@pagefind/linux-x64@1.3.0':
+    optional: true
+
+  '@pagefind/windows-x64@1.3.0':
+    optional: true
+
   '@pkgjs/parseargs@0.11.0':
     optional: true
+
+  '@polka/url@1.0.0-next.28': {}
 
   '@rollup/pluginutils@5.1.4(rollup@4.35.0)':
     dependencies:
@@ -3279,6 +3349,13 @@ snapshots:
   astro-meta-tags@0.3.1(astro@5.5.2(jiti@1.21.7)(rollup@4.35.0)(typescript@5.8.2)(yaml@2.7.0)):
     dependencies:
       astro: 5.5.2(jiti@1.21.7)(rollup@4.35.0)(typescript@5.8.2)(yaml@2.7.0)
+
+  astro-pagefind@1.8.3(astro@5.5.2(jiti@1.21.7)(rollup@4.35.0)(typescript@5.8.2)(yaml@2.7.0)):
+    dependencies:
+      '@pagefind/default-ui': 1.3.0
+      astro: 5.5.2(jiti@1.21.7)(rollup@4.35.0)(typescript@5.8.2)(yaml@2.7.0)
+      pagefind: 1.3.0
+      sirv: 3.0.1
 
   astro@5.5.2(jiti@1.21.7)(rollup@4.35.0)(typescript@5.8.2)(yaml@2.7.0):
     dependencies:
@@ -4515,6 +4592,14 @@ snapshots:
 
   package-manager-detector@1.0.0: {}
 
+  pagefind@1.3.0:
+    optionalDependencies:
+      '@pagefind/darwin-arm64': 1.3.0
+      '@pagefind/darwin-x64': 1.3.0
+      '@pagefind/linux-arm64': 1.3.0
+      '@pagefind/linux-x64': 1.3.0
+      '@pagefind/windows-x64': 1.3.0
+
   parse-entities@4.0.2:
     dependencies:
       '@types/unist': 2.0.11
@@ -4923,6 +5008,12 @@ snapshots:
     dependencies:
       is-arrayish: 0.3.2
 
+  sirv@3.0.1:
+    dependencies:
+      '@polka/url': 1.0.0-next.28
+      mrmime: 2.0.1
+      totalist: 3.0.1
+
   sisteransi@1.0.5: {}
 
   sitemap@8.0.0:
@@ -5042,6 +5133,8 @@ snapshots:
   to-regex-range@5.0.1:
     dependencies:
       is-number: 7.0.0
+
+  totalist@3.0.1: {}
 
   trim-lines@3.0.1: {}
 

--- a/src/components/header/header-actions.astro
+++ b/src/components/header/header-actions.astro
@@ -1,6 +1,7 @@
 ---
 import ButtonLink from "../button-link/button-link.astro";
 import HeaderButton from "./header-button.astro";
+import Search from "astro-pagefind/components/Search";
 
 export interface Props {
   mobile?: boolean;
@@ -12,6 +13,13 @@ const IS_LIVE = false;
 ---
 
 <div class="ml-auto flex items-center space-x-4">
+  <Search id="search" className="pagefind-ui" uiOptions={{
+
+      showImages: false,
+      translations: {
+        zero_results: "Couldn't find [SEARCH_TERM]"
+      }
+    }} />
   {
     !mobile ? (
       <>
@@ -40,3 +48,120 @@ const IS_LIVE = false;
     </HeaderButton>
   </label>
 </div>
+<script>
+document.addEventListener("DOMContentLoaded", function () {
+    const searchContainer = document.querySelector(".pagefind-ui");
+    const searchClear = document.querySelector(".pagefind-ui__search-clear");
+    const searchInput = searchContainer?.querySelector("input");
+    let selectedIndex = -1;
+
+    function updateSelection() {
+        const results = searchContainer?.querySelectorAll(".pagefind-ui__result");
+        if (!results) return;
+
+        results.forEach((result, index) => {
+            if (index === selectedIndex) {
+                result.classList.add("selected");
+                result.scrollIntoView({ block: "nearest", behavior: "smooth" });
+            } else {
+                result.classList.remove("selected");
+            }
+        });
+    }
+
+    document.addEventListener("keydown", function (event) {
+        if (!searchContainer || !searchInput) return;
+
+        const results = searchContainer.querySelectorAll(".pagefind-ui__result");
+        if (document.activeElement === searchInput) {
+            if (event.key === "ArrowDown") {
+                event.preventDefault();
+                selectedIndex = (selectedIndex + 1) % results.length;
+                updateSelection();
+            } else if (event.key === "ArrowUp") {
+                event.preventDefault();
+                selectedIndex = (selectedIndex - 1 + results.length) % results.length;
+                updateSelection();
+            } else if (event.key === "Enter" && selectedIndex >= 0) {
+                event.preventDefault();
+                results[selectedIndex].querySelector("a")?.click();
+            }
+        }
+    });
+
+    // Reset selection when the search query changes
+    searchInput?.addEventListener("input", function () {
+        selectedIndex = -1;
+    });
+
+});
+</script>
+<style is:global>
+ .pagefind-ui__result.selected {
+     background-color: #f5f5f5;
+     background-image: linear-gradient(to right, #3684B6 7px, transparent 5px);
+     -webkit-transform: translate3d(0, 0, 0);
+     transform: translate3d(0, 0, 0);
+}
+ .pagefind-ui__drawer {
+}
+ .pagefind-ui__message {
+     margin: 1em;
+}
+ .pagefind-ui__result mark {
+     background: #F9EB5D;
+     background-image: linear-gradient(to right, #F9EB5D 10%, #FCF4A7 100%);
+     margin: 4px;
+     padding-right: 6px;
+     padding-left: 6px;
+     padding-top: 2px;
+     padding-bottom: 2px;
+     color: #000000;
+     font-family: monospace;
+     border-radius: 4px;
+}
+ .pagefind-ui {
+     --pagefind-ui-scale: 1;
+     --pagefind-ui-primary: #141f36;
+     --pagefind-ui-text: black;
+     --pagefind-ui-border: #d8d8d8;
+     --pagefind-ui-border-width: 2px;
+     --pagefind-ui-border-radius: 0;
+     width: 50%;
+}
+ .pagefind-ui.yellow {
+     --pagefind-ui-background: #efc302;
+}
+ .pagefind-ui.red {
+     --pagefind-ui-background: #ffb9bb;
+     width: 50%;
+}
+ .pagefind-ui .pagefind-ui__drawer:not(.pagefind-ui__hidden) {
+     position: absolute;
+     left: auto;
+     right: 0;
+     margin-top: 0px;
+     width:50vw;
+     z-index: 9999;
+     overflow-y: auto;
+     box-shadow: 0 10px 10px -5px rgba(0, 0, 0, 0.2), 0 2px 2px 0 rgba(0, 0, 0, 0.1);
+     border-bottom-right-radius: var(--pagefind-ui-border-radius);
+     border-bottom-left-radius: var(--pagefind-ui-border-radius);
+     background-color: var(--pagefind-ui-background);
+}
+ .pagefind-ui__result{
+     padding: 0 2em 1em !important;
+}
+ .pagefind-ui .pagefind-ui__result-link {
+     color: var(--pagefind-ui-primary);
+}
+ .pagefind-ui .pagefind-ui__result-excerpt {
+     color: var(--pagefind-ui-text);
+}
+ @media (max-width: 1280px) {
+     .pagefind-ui {
+         display:none;
+    }
+}
+
+</style>


### PR DESCRIPTION
integrates [Pagefind](https://pagefind.app/) to enable static search functionality on the EuroPython website. Pagefind provides client-side search indexing, improving site search performance without requiring a backend service.