### PR TITLE
Standardise summit pages

### DIFF
--- a/src/content/pages/programme/c-api-summit.mdx
+++ b/src/content/pages/programme/c-api-summit.mdx
@@ -3,7 +3,7 @@ title: C API Summit
 subtitle: A summit for Python's C API stakeholders to discuss its state and future.
 
 ---
-## C API Summit
+# C API Summit
 The **C API Summit** aims to bring together various stakeholders of Python's C API to discuss its current state, address challenges, and align on ongoing work.
 
 
@@ -16,7 +16,7 @@ The event will be hosted at the **Prague Congress Centre (PCC)**, Room [TBA].
 ---
 
 
-#### Meet the Community
+## Meet the Community
 
 The main goal of this summit is for various stakeholders of Python's C API to meet and discuss about the state of the API, existing challenges and ongoing work.
 
@@ -27,7 +27,7 @@ We are particularly looking for contributors and maintainers of:
 - Applications that embed Python
 - Similar projects working in this area
 
-#### Presentations
+## Presentations
 
 If there is a topic you would like to present, please indicate it in the form and fill it in early.
 
@@ -35,7 +35,8 @@ Summit presentations are brief, intended to get everyone on the same page and st
 
 We are looking to discuss advanced topics.
 
-#### Tentative Agenda (subject to change)
+## Tentative Agenda (subject to change)
+
 - **9:00 AM**: Meet and greet – unconference-style post-it board organization
 - **9:30 AM**: Presentations (30 minutes each: 10 min presentation + 20 min discussion)
 - **11:00 AM**: Coffee break
@@ -46,7 +47,7 @@ We are looking to discuss advanced topics.
 - **6:30 PM**: Dinner
 
 
-#### Registration
+## Registration
 
 To be part of the C API summit [register your interest now!](https://docs.google.com/forms/d/e/1FAIpQLSfUT8BEHyt-Nlwo6aEmnEHdn1y_rkCoShEKYuHm4LhWvbMjjw/viewform) 👈
 

--- a/src/content/pages/programme/c-api-summit.mdx
+++ b/src/content/pages/programme/c-api-summit.mdx
@@ -3,18 +3,16 @@ title: C API Summit
 subtitle: A summit for Python's C API stakeholders to discuss its state and future.
 
 ---
+
 # C API Summit
+
 The **C API Summit** aims to bring together various stakeholders of Python's C API to discuss its current state, address challenges, and align on ongoing work.
 
-
-**WHEN?**
-The summit will take place on **Monday, July 14th** or **Tuesday, July 15th** (confirmation pending).
-
-**WHERE?**
-The event will be hosted at the **Prague Congress Centre (PCC)**, Room [TBA].
+* **When**: Monday, July 14th or Tuesday, July 15th (to be confirmed)
+* **Where**: Prague Congress Centre (PCC), Room to be announced
+* **Who can join**: Anyone with a valid in-person EuroPython 2025 ticket
 
 ---
-
 
 ## Meet the Community
 

--- a/src/content/pages/programme/rust-summit.mdx
+++ b/src/content/pages/programme/rust-summit.mdx
@@ -8,9 +8,9 @@ subtitle: The Rust Summit aims to bring together various stakeholders of Pythonâ
 
 The **Rust Summit** aims to bring together various stakeholders of Pythonâ€™s Rust ecosystem to discuss its current state, address challenges, and align on ongoing work.
 
-**WHEN?** The summit will take place on **Monday, July 14th** or **Tuesday, July 15th** (confirmation pending).
-
-**WHERE?** The event will be hosted at the **Prague Congress Centre (PCC)**, Room \[TBA\].
+* **When**: Monday, July 14th or Tuesday, July 15th (to be confirmed)
+* **Where**: Prague Congress Centre (PCC), Room to be announced
+* **Who can join**: Anyone with a valid in-person EuroPython 2025 ticket
 
 ---
 

--- a/src/content/pages/programme/rust-summit.mdx
+++ b/src/content/pages/programme/rust-summit.mdx
@@ -3,7 +3,8 @@ title: Rust Summit
 subtitle: The Rust Summit aims to bring together various stakeholders of Python’s Rust ecosystem to discuss its current state, address challenges, and align on ongoing work.
 
 ---
-## **Rust Summit**
+
+# Rust Summit
 
 The **Rust Summit** aims to bring together various stakeholders of Python’s Rust ecosystem to discuss its current state, address challenges, and align on ongoing work.
 
@@ -13,7 +14,7 @@ The **Rust Summit** aims to bring together various stakeholders of Python’s Ru
 
 ---
 
-#### **Meet the Community**
+## Meet the Community
 
 The main goal of this summit is for various stakeholders of Python’s Rust ecosystem to meet, learn, and discuss about the Rust ecosystem in Python, how Python can benefit from Rust, and anything related to the adaptation of thread-free Python.
 
@@ -25,7 +26,7 @@ We are particularly looking for contributors and maintainers of:
 * New Python libraries that are written in Rust
 * Other Python projects that can benefit from using Rust
 
-#### **Presentations**
+## Presentations
 
 If there is a topic you would like to present, please indicate it in the form and fill it in early.
 
@@ -35,7 +36,7 @@ Deep dive presentations are 45 mins in total (35 mins presentation and 10 mins Q
 
 We are also open to suggestions for unconference-style activities.
 
-#### **Tentative Agenda (subject to change)**
+## Tentative Agenda (subject to change)
 
 * **9:00 AM**: Meet and greet – unconference-style post-it board organization
 * **9:30 AM**: Sparkling Presentations (30 minutes each: 10 min presentation \+ 20 min discussion)
@@ -46,7 +47,7 @@ We are also open to suggestions for unconference-style activities.
 * **6:00 PM**: Round-up/plenary session for feedback and conclusions
 * **6:30 PM**: Dinner
 
-#### **Registration**
+## Registration
 
 To be part of the Rust summit [register your interest now\!](https://docs.google.com/forms/d/e/1FAIpQLSe8Wjahr3-agTr4lS8_u3ifel_9XYAQEGk71IAAIh_h2eRUzw/viewform?usp=preview) 👈
 

--- a/src/content/pages/programme/wasm-summit.mdx
+++ b/src/content/pages/programme/wasm-summit.mdx
@@ -11,6 +11,7 @@ The **WebAssembly Summit** aims to bring together maintainers and users of Pytho
 * **Where**: Prague Congress Centre (PCC), Room to be announced
 * **Who can join**: Anyone with a valid in-person EuroPython 2025 ticket
 
+---
 
 ## Agenda
 

--- a/src/content/pages/programme/wasm-summit.mdx
+++ b/src/content/pages/programme/wasm-summit.mdx
@@ -5,12 +5,11 @@ subtitle: A summit to bring together maintainers and users of Python with WebAss
 
 # WebAssembly Summit
 
+The **WebAssembly Summit** aims to bring together maintainers and users of Python with WebAssembly, to discuss the state of this ecosystem, existing challenges, and ongoing work.
+
 * **When**: Monday, July 14th or Tuesday, July 15th (to be confirmed)
 * **Where**: Prague Congress Centre (PCC), Room to be announced
 * **Who can join**: Anyone with a valid in-person EuroPython 2025 ticket
-
-
-This summit aims to bring together maintainers and users of Python with WebAssembly, to discuss the state of this ecosystem, existing challenges, and ongoing work.
 
 
 ## Agenda


### PR DESCRIPTION
The three summit pages are similar, but differently formatted:

* https://ep2025.europython.eu/programme/c-api-summit/
* https://ep2025.europython.eu/programme/wasm-summit/
* https://ep2025.europython.eu/programme/rust-summit/

First, make sure all have standard headers (h1 for first-level, h2 for second-level, and so on; not h2 for first-level and h4 for second-level) - this is partly an accessibility thing.

Then give all the same type of when/where/who sections at the top.

And move the intro summit before that.