### PR TITLE
Short urls for sessions.

### DIFF
--- a/astro.config.mjs
+++ b/astro.config.mjs
@@ -76,6 +76,7 @@ export default defineConfig({
   redirects: {
     "/planning/": "https://forms.gle/riw6CvML8ck94A4V9",
     "/reviewers/": "https://forms.gle/4GTJjwZ1nHBGetM18",
+    "/[code]": "/session/[...slug]",
   },
   integrations: [
     preload(),

--- a/astro.config.mjs
+++ b/astro.config.mjs
@@ -76,7 +76,6 @@ export default defineConfig({
   redirects: {
     "/planning/": "https://forms.gle/riw6CvML8ck94A4V9",
     "/reviewers/": "https://forms.gle/4GTJjwZ1nHBGetM18",
-    "/[code]": "/session/[...slug]",
   },
   integrations: [
     preload(),

--- a/src/pages/[code].astro
+++ b/src/pages/[code].astro
@@ -1,0 +1,16 @@
+---
+import { getCollection } from "astro:content";
+
+export async function getStaticPaths() {
+  const sessions = await getCollection("sessions");
+  return sessions.map((entry) => ({
+    params: { code: entry.data.code },
+    props: { slug: entry.id},
+  }));
+}
+
+const { slug } = Astro.props;
+
+---
+
+<meta http-equiv="refresh" content=`0;url=/session/${slug}` />

--- a/src/pages/[code].astro
+++ b/src/pages/[code].astro
@@ -1,6 +1,5 @@
 ---
 import { getCollection } from "astro:content";
-
 export async function getStaticPaths() {
   const sessions = await getCollection("sessions");
   return sessions.map((entry) => ({
@@ -8,7 +7,6 @@ export async function getStaticPaths() {
     props: { slug: entry.id},
   }));
 }
-
 const { slug } = Astro.props;
 return Astro.rewrite(`/session/${slug}`);
 ---

--- a/src/pages/[code].astro
+++ b/src/pages/[code].astro
@@ -10,7 +10,5 @@ export async function getStaticPaths() {
 }
 
 const { slug } = Astro.props;
-
+return Astro.rewrite(`/session/${slug}`);
 ---
-
-<meta http-equiv="refresh" content=`0;url=/session/${slug}` />

--- a/src/pages/session/[slug].astro
+++ b/src/pages/session/[slug].astro
@@ -235,14 +235,10 @@ const nextSessionsOrdered = sameRoomNextSession
 </Layout>
 
 <script is:inline define:vars={{ slug }}>
-  // Check if the current URL contains the entry ID
   const currentUrl = window.location.pathname;
   const expectedUrl = `/session/${slug}`;
 
-  // If the URL doesn't match the expected URL with the entry ID, replace it
   if (currentUrl !== expectedUrl) {
-    // Use history.replaceState to update the URL without refreshing the page
     window.history.replaceState({}, '', expectedUrl);
-    console.log(`URL updated to match entry ID: ${expectedUrl}`);
   }
 </script>

--- a/src/pages/session/[slug].astro
+++ b/src/pages/session/[slug].astro
@@ -21,7 +21,7 @@ export async function getStaticPaths() {
 const sessions = await getCollection("sessions");
 
 const { entry } = Astro.props;
-
+const slug = entry.id;
 const speakers = await getEntries(entry.data.speakers);
 
 // Resolve session codes to session data
@@ -233,3 +233,16 @@ const nextSessionsOrdered = sameRoomNextSession
     </footer>
   </Section>
 </Layout>
+
+<script is:inline define:vars={{ slug }}>
+  // Check if the current URL contains the entry ID
+  const currentUrl = window.location.pathname;
+  const expectedUrl = `/session/${slug}`;
+
+  // If the URL doesn't match the expected URL with the entry ID, replace it
+  if (currentUrl !== expectedUrl) {
+    // Use history.replaceState to update the URL without refreshing the page
+    window.history.replaceState({}, '', expectedUrl);
+    console.log(`URL updated to match entry ID: ${expectedUrl}`);
+  }
+</script>


### PR DESCRIPTION
pathname  /<session_code> redirects now to session
eg. https://ep2025-code.ep-preview.click/3BQFTP -> https://ep2025-code.ep-preview.click/session/pyscript-as-infrastructure-running-edublocks-at-scale-without-the-cost/
