### PR TITLE
Add text to PyCon FI logo

### DIFF
--- a/src/content/sponsors/pycon-fi/pycon-fi.svg
+++ b/src/content/sponsors/pycon-fi/pycon-fi.svg
@@ -4,9 +4,9 @@
 <svg
    version="1.0"
    id="svg2"
-   width="88.113998pt"
+   width="237.114pt"
    height="89.039001pt"
-   viewBox="-3 -3 119.56869 120.8239"
+   viewBox="-3 -3 321.75871 120.8239"
    xmlns="http://www.w3.org/2000/svg"
    xmlns:svg="http://www.w3.org/2000/svg"
    xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
@@ -47,7 +47,7 @@
      d="m 86.131753,29.15717 v 11.90625 c 0,9.230755 -7.825895,16.999999 -16.75,17 h -26.78125 c -7.335833,0 -13.406249,6.278483 -13.40625,13.625 v 25.531247 c 0,7.266343 6.318588,11.540323 13.40625,13.625003 8.487331,2.49561 16.626237,2.94663 26.78125,0 6.750155,-1.95439 13.406253,-5.88761 13.40625,-13.625003 V 87.00092 h -26.78125 v -3.40625 h 26.78125 13.406254 c 7.792463,0 10.696253,-5.435408 13.406243,-13.59375 2.79933,-8.398886 2.68022,-16.475776 0,-27.25 -1.92578,-7.757441 -5.60387,-13.59375 -13.406243,-13.59375 z m -15.0625,64.65625 c 2.779478,3e-6 5.03125,2.277417 5.03125,5.093747 -2e-6,2.826353 -2.251775,5.125003 -5.03125,5.125003 -2.76955,0 -5.03125,-2.29865 -5.03125,-5.125003 2e-6,-2.81633 2.261697,-5.093747 5.03125,-5.093747 z"
      id="path9" />
   <path
-     style="display:inline;fill:#ffffff;fill-opacity:1;stroke:#002f6c;stroke-opacity:1;stroke-width:1.00009222;stroke-dasharray:none"
+     style="display:inline;fill:#ffffff;fill-opacity:1;stroke:#002f6c;stroke-width:1.00009;stroke-dasharray:none;stroke-opacity:1"
      d="M 55.413003,0.50092002 C 50.82935,0.52221802 46.452064,0.91313772 42.600503,1.59467 31.254287,3.5991738 29.194254,7.7947721 29.194253,15.53217 v 10.21875 h 26.8125 v 3.40625 h -26.8125 -10.0625 c -7.792459,0 -14.615759,4.683717 -16.75,13.59375 -2.46182001,10.212966 -2.57101511,16.586023 0,27.25 1.9059283,7.937852 6.4575432,13.593748 14.25,13.59375 h 9.21875 v -12.25 c 0,-8.849902 7.657144,-16.656248 16.75,-16.65625 h 26.78125 c 7.454951,0 13.406253,-6.138164 13.40625,-13.625 V 15.53217 c 0,-7.2663389 -6.12998,-12.7247774 -13.40625,-13.9375 C 64.775766,0.82794472 59.996656,0.47962172 55.413003,0.50092002 Z m -14.5,8.21875008 c 2.769547,0 5.03125,2.2986459 5.03125,5.1249999 -2e-6,2.816336 -2.261703,5.09375 -5.03125,5.09375 -2.779476,-1e-6 -5.03125,-2.277415 -5.03125,-5.09375 -1e-6,-2.826353 2.251774,-5.1249999 5.03125,-5.1249999 z"
      id="path7" />
   <g
@@ -92,4 +92,34 @@
        y="-55.97578"
        transform="rotate(90)" />
   </g>
+  <text
+     xml:space="preserve"
+     style="font-size:12.2128px;font-family:'Helvetica Neue';-inkscape-font-specification:'Helvetica Neue, Normal';opacity:1;fill:#000000;stroke:#000000;stroke-width:2.62847"
+     x="115.29726"
+     y="29.118809"
+     id="text4"><tspan
+       style="font-style:normal;font-variant:normal;font-weight:bold;font-stretch:normal;font-size:28.4966px;font-family:'Helvetica Neue';-inkscape-font-specification:'Helvetica Neue, Bold';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-east-asian:normal;fill:#002f6c;fill-opacity:1;stroke:none;stroke-width:2.62847"
+       x="115.29726"
+       y="29.118809"
+       id="tspan9">PyCon Finland</tspan><tspan
+       style="font-style:normal;font-variant:normal;font-weight:bold;font-stretch:normal;font-size:20.3547px;font-family:'Helvetica Neue';-inkscape-font-specification:'Helvetica Neue, Bold';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-east-asian:normal;stroke:none;stroke-width:2.62847"
+       x="115.29726"
+       y="57.06213"
+       id="tspan6"
+       dx="0 0 0 0 0 0 2.5928996 0.99131775 0 0">Friday 17 Oct 2025</tspan><tspan
+       style="font-style:normal;font-variant:normal;font-weight:bold;font-stretch:normal;font-size:20.3547px;font-family:'Helvetica Neue';-inkscape-font-specification:'Helvetica Neue, Bold';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-east-asian:normal;stroke:none;stroke-width:2.62847"
+       x="115.29726"
+       y="82.505501"
+       dx="0 0 0 0 0 0 0 0 0 0.99131775"
+       id="tspan7">Jyväskylä</tspan><tspan
+       style="font-style:italic;font-variant:normal;font-weight:bold;font-stretch:normal;font-size:13.5698px;font-family:'Helvetica Neue';-inkscape-font-specification:'Helvetica Neue, Bold';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-east-asian:normal;stroke:none;stroke-width:2.62847"
+       x="115.29726"
+       y="101.55104"
+       dx="0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0.99131775"
+       id="tspan10">In cooperation with PloneConf</tspan><tspan
+       style="font-style:normal;font-variant:normal;font-weight:bold;font-stretch:normal;font-size:20.3547px;font-family:'Helvetica Neue';-inkscape-font-specification:'Helvetica Neue, Bold';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-east-asian:normal;stroke:none;stroke-width:2.62847"
+       x="115.29726"
+       y="117.22411"
+       dx="0.99131775"
+       id="tspan8" /></text>
 </svg>


### PR DESCRIPTION
Add some extra info to the PyCon Finland image so it's not just the two-snakes logo in the community partners section at https://ep2025.europython.eu

@thepetk Thanks for the suggestion!