### PR TITLE
Disabled html compress due to css nesting issues

### DIFF
--- a/astro.config.mjs
+++ b/astro.config.mjs
@@ -117,6 +117,7 @@ export default defineConfig({
     pagefind(),
     deleteUnusedImages(),
     compress({
+      HTML: false,
       CSS: false,
       SVG: false,
     }),

--- a/src/layouts/Layout.astro
+++ b/src/layouts/Layout.astro
@@ -29,6 +29,7 @@ const externalDomain = new URL(Astro.site || "").hostname;
     <BaseHead title={title} description={description} />
     <slot name="head" />
     </Fragment>
+  </head>
 
   <body>
       <header>


### PR DESCRIPTION
Disable html compression due to issues with css nesting
https://github.com/PlayForm/Compress/issues/400