### PR TITLE
Update sponsors pages and fix url 3xx redirects

### DIFF
--- a/public/prague.svg
+++ b/public/prague.svg
@@ -1,6 +1,6 @@
   <!--?xml version="1.0" encoding="utf-8"?-->
   <svg
-    xmlns="http://www.w3.org/2000/svg"
+    xmlns="https://www.w3.org/2000/svg"
     viewBox="-1.0774 3.6607 501.5978 131.0469"
   >
     <path

--- a/src/components/SponsorCard.astro
+++ b/src/components/SponsorCard.astro
@@ -67,7 +67,7 @@ const logo = sponsorLogos[sponsor.id];
     description && (
       <div class="flex-1">
         <h2 id=`sponsor-${sponsorId}` class="sponsor text-2xl font-bold mb-2 ">
-          { !isSponsorPage && tier !== 'Partners' ?
+          { !isSponsorPage && tier !== 'Partners' && ["Diamond", "Platinum"].includes(tier) ?
             <a href={`/sponsor/${sponsor.id}`}>
             {title}
             </a> :
@@ -103,7 +103,7 @@ const logo = sponsorLogos[sponsor.id];
         {(tier !== "Partners") && website && (
           <div class="website-btn-container flex flex-col sm:flex-row justify-center gap-2 mt-4">
 
-            { !isSponsorPage && sponsor.body && tier && ["Gold", "Platinum"].includes(tier) &&
+            { !isSponsorPage && sponsor.body && tier && ["Diamond", "Platinum"].includes(tier) &&
             <a href={`/sponsor/${sponsor.id}`} class="website-btn-outline">
               About {title}
             </a>

--- a/src/components/SponsorLogo.astro
+++ b/src/components/SponsorLogo.astro
@@ -20,7 +20,7 @@ const {
 } = sponsor.data;
 
 const logo = sponsorLogos[sponsor.id];
-const slug = tier==="Partners"? `/community-partners#sponsor-${sponsorId}`: tier==="Platinum" ? `/sponsor/${sponsorId}` : tier==="Media Partners" ? `/media-partners#sponsor-${sponsorId}` : tier==="Startups" ? `/startups#sponsor-${sponsorId}` : ""
+const slug = tier==="Partners"? `/community-partners#sponsor-${sponsorId}`: tier==="Platinum" ? `/sponsor/${sponsorId}` : tier==="Media Partners" ? `/media-partners#sponsor-${sponsorId}` : tier==="Startups" ? `/startups#sponsor-${sponsorId}` : `/sponsors#sponsor-${sponsorId}`
 
 ---
 

--- a/src/components/sections/subscribe.astro
+++ b/src/components/sections/subscribe.astro
@@ -2,9 +2,9 @@
 import Button from "@ui/Button.astro";
 import Section from "@ui/Section.astro"
 const socialLinks = [
-  { href: "https://linkedin.com/sponsor/europython/", icon: "linkedin", label: "LinkedIn" },
-  { href: "https://instagram.com/europython/", icon: "instagram", label: "Instagram" },
-  { href: "https://youtube.com/channel/UC98CzaYuFNAA_gOINFB0e4Q", icon: "youtube", label: "YouTube" },
+{ href: "https://www.linkedin.com/company/europython/", icon: "linkedin", label: "LinkedIn" },
+  { href: "https://www.instagram.com/europython/", icon: "instagram", label: "Instagram" },
+  { href: "https://www.youtube.com/channel/UC98CzaYuFNAA_gOINFB0e4Q", icon: "youtube", label: "YouTube" },
   { href: "https://fosstodon.org/@europython", icon: "mastodon", label: "Mastodon" },
   { href: "https://bsky.app/profile/europython.eu", icon: "bluesky", label: "Bluesky" },
   { href: "https://x.com/europython", icon: "x", label: "X (formerly Twitter)" },

--- a/src/data/links.json
+++ b/src/data/links.json
@@ -314,11 +314,11 @@
       "items": [
         {
           "name": "EuroPython Society",
-          "path": "https://europython-society.org"
+          "path": "https://europython-society.org/"
         },
         {
           "name": "EuroPython Blog",
-          "path": "https://blog.europython.eu"
+          "path": "https://blog.europython.eu/"
         }
       ]
     }
@@ -343,11 +343,11 @@
   ],
   "socials": {
     "mastodon": "https://fosstodon.org/@europython",
-    "linkedin": "https://linkedin.com/company/europython",
+    "linkedin": "https://www.linkedin.com/company/europython",
     "github": "https://github.com/europython",
     "bluesky": "https://bsky.app/profile/europython.eu",
     "twitter": "https://x.com/europython",
-    "instagram": "https://instagram.com/europython/",
-    "youtube": "https://youtube.com/channel/UC98CzaYuFNAA_gOINFB0e4Q"
+    "instagram": "https://www.instagram.com/europython/",
+    "youtube": "https://www.youtube.com/channel/UC98CzaYuFNAA_gOINFB0e4Q"
   }
 }

--- a/src/pages/sponsor/[sponsor]/index.astro
+++ b/src/pages/sponsor/[sponsor]/index.astro
@@ -14,7 +14,7 @@ export async function getStaticPaths() {
   const isProduction = import.meta.env.MODE === "production";
 
   const sponsors = await getCollection("sponsors", ({ data }) =>
-  data.tier && ["Gold", "Platinum"].includes(data.tier) && (isProduction ? data.draft !== true : true)
+  data.tier && ["Diamond", "Platinum"].includes(data.tier) && (isProduction ? data.draft !== true : true)
   );
 
   return sponsors.map((sponsor: any) => ({


### PR DESCRIPTION
Sponsors logo links from main page goes to `/sponsors#sponsor-<name>`.
Sponsors pages for Diamond and Platinum.
Fix sponsor headers links ( they are removed when there is no about page).
Fixed 3xx url which were permanent redirections.