### PR TITLE
Update accessibility.mdx

### DIFF
--- a/src/content/pages/accessibility.mdx
+++ b/src/content/pages/accessibility.mdx
@@ -29,7 +29,7 @@ You're very welcome to ask about any accessibility needs. These may include, for
 
 **Before the conference**, you can leave us a note when ordering your tickets or contact us via email at helpdesk@europython.eu.
 
-**During the conference**, you can visit our Info Desk at registration or speak with our volunteers wearing a yellow conference t-shirt. You can also reach out via the Discord using the "support" channel – please bear with us if takes a moment to respond
+**During the conference**, you can visit our Info Desk at registration or speak with our volunteers wearing a yellow conference t-shirt. Registred ticket holders can also reach out via the Discord using the "support" channel – please bear with us if takes a moment to respond.
 
 If you need help for things like designated seating, maintaining clear pathways, or anything else, feel free to speak to the volunteer coordinating the session in the talk rooms as well.
 


### PR DESCRIPTION
Making it clear that you need to ticket to ask Discord question

Reason: A helpdesk request where the old wording caused someone to search for the discord invite and not finding any info.