### PR TITLE
feat: Add AV internal link redirects for 2025

### DIFF
--- a/astro.config.mjs
+++ b/astro.config.mjs
@@ -123,19 +123,31 @@ export default defineConfig({
     "/programme/wasm-summit": "/session/webassembly-summit",
     "/discord": "https://discord.gg/BhTN2zJPMh",
     // For AV team internal use: break screens
-    "/break/forum-hall": "https://overlays.gbdl.in/ep-forum-hall/scene-schedule.html",
-    "/break/north-hall": "https://overlays.gbdl.in/ep-north-hall/scene-schedule.html",
-    "/break/south-hall-2a": "https://overlays.gbdl.in/ep-south-hall-2a/scene-schedule.html",
-    "/break/south-hall-2b": "https://overlays.gbdl.in/ep-south-hall-2b/scene-schedule.html",
-    "/break/terrace-2a": "https://overlays.gbdl.in/ep-terrace-2a/scene-schedule.html",
-    "/break/terrace-2b": "https://overlays.gbdl.in/ep-terrace-2b/scene-schedule.html",
+    "/break/forum-hall":
+      "https://overlays.gbdl.in/ep-forum-hall/scene-schedule.html",
+    "/break/north-hall":
+      "https://overlays.gbdl.in/ep-north-hall/scene-schedule.html",
+    "/break/south-hall-2a":
+      "https://overlays.gbdl.in/ep-south-hall-2a/scene-schedule.html",
+    "/break/south-hall-2b":
+      "https://overlays.gbdl.in/ep-south-hall-2b/scene-schedule.html",
+    "/break/terrace-2a":
+      "https://overlays.gbdl.in/ep-terrace-2a/scene-schedule.html",
+    "/break/terrace-2b":
+      "https://overlays.gbdl.in/ep-terrace-2b/scene-schedule.html",
     // For AV team internal use: VDO ninja screen share
-    "/ninja/forum-hall": "https://vdo.ninja/?room=EuroPython_2025_Forum_Hall&hash=338a&do",
-    "/ninja/north-hall": "https://vdo.ninja/?room=EuroPython_2025_North_Hall&hash=338a&do",
-    "/ninja/south-hall-2a": "https://vdo.ninja/?room=EuroPython_2025_Southhall_2A&hash=338a&do",
-    "/ninja/south-hall-2b": "https://vdo.ninja/?room=EuroPython_2025_Southhall_2B&hash=338a&do",
-    "/ninja/terrace-2a": "https://vdo.ninja/?room=EuroPython_2025_Terrace_2A&hash=338a&do",
-    "/ninja/terrace-2b": "https://vdo.ninja/?room=EuroPython_2025_Terrace_2B&hash=338a&do",
+    "/ninja/forum-hall":
+      "https://vdo.ninja/?room=EuroPython_2025_Forum_Hall&hash=338a&do",
+    "/ninja/north-hall":
+      "https://vdo.ninja/?room=EuroPython_2025_North_Hall&hash=338a&do",
+    "/ninja/south-hall-2a":
+      "https://vdo.ninja/?room=EuroPython_2025_Southhall_2A&hash=338a&do",
+    "/ninja/south-hall-2b":
+      "https://vdo.ninja/?room=EuroPython_2025_Southhall_2B&hash=338a&do",
+    "/ninja/terrace-2a":
+      "https://vdo.ninja/?room=EuroPython_2025_Terrace_2A&hash=338a&do",
+    "/ninja/terrace-2b":
+      "https://vdo.ninja/?room=EuroPython_2025_Terrace_2B&hash=338a&do",
   },
   integrations: [
     mdx(),

--- a/astro.config.mjs
+++ b/astro.config.mjs
@@ -122,6 +122,20 @@ export default defineConfig({
     "/programme/c-api-summit": "/session/c-api-summit",
     "/programme/wasm-summit": "/session/webassembly-summit",
     "/discord": "https://discord.gg/BhTN2zJPMh",
+    // For AV team internal use: break screens
+    "/break/forum-hall": "https://overlays.gbdl.in/ep-forum-hall/scene-schedule.html",
+    "/break/north-hall": "https://overlays.gbdl.in/ep-north-hall/scene-schedule.html",
+    "/break/south-hall-2a": "https://overlays.gbdl.in/ep-south-hall-2a/scene-schedule.html",
+    "/break/south-hall-2b": "https://overlays.gbdl.in/ep-south-hall-2b/scene-schedule.html",
+    "/break/terrace-2a": "https://overlays.gbdl.in/ep-terrace-2a/scene-schedule.html",
+    "/break/terrace-2b": "https://overlays.gbdl.in/ep-terrace-2b/scene-schedule.html",
+    // For AV team internal use: VDO ninja screen share
+    "/ninja/forum-hall": "https://vdo.ninja/?room=EuroPython_2025_Forum_Hall&hash=338a&do",
+    "/ninja/north-hall": "https://vdo.ninja/?room=EuroPython_2025_North_Hall&hash=338a&do",
+    "/ninja/south-hall-2a": "https://vdo.ninja/?room=EuroPython_2025_Southhall_2A&hash=338a&do",
+    "/ninja/south-hall-2b": "https://vdo.ninja/?room=EuroPython_2025_Southhall_2B&hash=338a&do",
+    "/ninja/terrace-2a": "https://vdo.ninja/?room=EuroPython_2025_Terrace_2A&hash=338a&do",
+    "/ninja/terrace-2b": "https://vdo.ninja/?room=EuroPython_2025_Terrace_2B&hash=338a&do",
   },
   integrations: [
     mdx(),


### PR DESCRIPTION
AV team needs some nicer URLs for internal stuff, to be exact:
- Links for break screens for projector screens
- Links for speakers to join in scene share, as a backup for the HDMI cable.