### PR TITLE
Add Discord invite on public pages

### DIFF
--- a/src/content/pages/accessibility.mdx
+++ b/src/content/pages/accessibility.mdx
@@ -29,7 +29,7 @@ You're very welcome to ask about any accessibility needs. These may include, for
 
 **Before the conference**, you can leave us a note when ordering your tickets or contact us via email at helpdesk@europython.eu.
 
-**During the conference**, you can visit our Info Desk at registration or speak with our volunteers wearing a yellow conference t-shirt. Registred ticket holders can also reach out via the Discord using the "support" channel – please bear with us if takes a moment to respond.
+**During the conference**, you can visit our Info Desk at registration or speak with our volunteers wearing a yellow conference t-shirt. Registered ticket holders can also reach out via the Discord using the "support" channel – please bear with us if takes a moment to respond.
 
 If you need help for things like designated seating, maintaining clear pathways, or anything else, feel free to speak to the volunteer coordinating the session in the talk rooms as well.
 

--- a/src/content/pages/accessibility.mdx
+++ b/src/content/pages/accessibility.mdx
@@ -29,7 +29,7 @@ You're very welcome to ask about any accessibility needs. These may include, for
 
 **Before the conference**, you can leave us a note when ordering your tickets or contact us via email at helpdesk@europython.eu.
 
-**During the conference**, you can visit our Info Desk at registration or speak with our volunteers wearing a yellow conference t-shirt. Registered ticket holders can also reach out via the Discord using the "support" channel – please bear with us if takes a moment to respond.
+**During the conference**, you can visit our Info Desk at registration or speak with our volunteers wearing a yellow conference t-shirt. Registered ticket holders can also reach out via the [Discord server](/discord) using the "support" channel – please bear with us if it takes a moment to respond.
 
 If you need help for things like designated seating, maintaining clear pathways, or anything else, feel free to speak to the volunteer coordinating the session in the talk rooms as well.
 

--- a/src/content/pages/faq.mdx
+++ b/src/content/pages/faq.mdx
@@ -230,5 +230,5 @@ You can find detailed information about accessibility and how to navigate the ve
 
 <Accordion title="How can I join the conference Discord server?" id="discord">
 During the event, we provide a Discord server for announcements, social interactions, and all other digital communication.
-Please join the server using this [Discord invidation link](/discord).
+Please join the server using this [Discord invitation link](/discord).
 </Accordion>

--- a/src/content/pages/faq.mdx
+++ b/src/content/pages/faq.mdx
@@ -227,3 +227,8 @@ Our goal is to make EuroPython sponsorship accessible to a wide range of organis
 <Accordion title="Where can I find accessibility information and directions to some of the rooms?" id="accessibility">
 You can find detailed information about accessibility and how to navigate the venues, including lifts, room locations, and other facilities, on our [Accessibility page](/accessibility).
 </Accordion>
+
+<Accordion title="How can I join the conference Discord server?" id="discord">
+During the event, we provide a Discord server for announcements, social interactions, and all other digital communication.
+Please join the server using this [Discord invidation link](/discord).
+</Accordion>

--- a/src/content/pages/remote.mdx
+++ b/src/content/pages/remote.mdx
@@ -25,6 +25,7 @@ Remote participation between 16-18 July (Wednesday - Friday):
 - Text-based discussions with available speakers.
 - Online job board and chat with sponsors at the remote booths.
 - On-demand viewing, which will be available hours after the live stream.
+- Access to our [conference Discord server](/discord).
 
 <Note type="warning">Tutorials and Workshops on 14 and 15 July will not be streamed.</Note>
 

--- a/src/content/pages/sponsorship/information.mdx
+++ b/src/content/pages/sponsorship/information.mdx
@@ -124,7 +124,7 @@ However, we strongly recommend keeping booths staffed throughout the opening hou
   - If you need additional time for setup, please let us know and we will try to accommodate your request.
   - If you are unable to set up on Tuesday, you can access the venue on **Wednesday, 16 July from 08:00** to finish your setup.
 
-👉 Please note: During the live event, the schedule may change quickly. We will communicate any updates in the **sponsor-lounge** channel on our conference Discord community.
+👉 Please note: During the live event, the schedule may change quickly. We will communicate any updates in the **sponsor-lounge** channel on our [conference Discord community](/discord).
 
 <h5> Booth Teardown – Friday, 18 July </h5>
 

--- a/src/content/pages/volunteers.mdx
+++ b/src/content/pages/volunteers.mdx
@@ -24,7 +24,7 @@ We will also have a small number of perks for you, some small gifts to say "than
 * 😎 Get an awesome EuroPython Volunteer T-shirt that you can keep and show off to your friends
 * ♾️ A mention on the website to stay there forever
 * 🤝 Be part of a great team and make new friends
-* 📸 A special group photo with all volunteers (time will be announced in the *#onsite-volunteers* channel on Discord)
+* 📸 A special group photo with all volunteers (time will be announced in the *#volunteers-lounge* channel on [Discord](/discord))
 * 🎉 And a big applause during the closing session of the conference
 
 ## What Volunteering at EuroPython looks like

--- a/src/data/links.json
+++ b/src/data/links.json
@@ -162,7 +162,7 @@
         {
           "name": "Discord",
           "path": "/discord"
-        }
+        },
         {
           "name": "Code of Conduct",
           "path": "https://www.europython-society.org/coc/"

--- a/src/data/links.json
+++ b/src/data/links.json
@@ -160,6 +160,10 @@
           "path": "/faq"
         },
         {
+          "name": "Discord",
+          "path": "/discord"
+        }
+        {
           "name": "Code of Conduct",
           "path": "https://www.europython-society.org/coc/"
         }


### PR DESCRIPTION
Add the Discord invite URL in many places:

* Navbar (Attend > Discord)

<img width="286" height="564" alt="image" src="https://github.com/user-attachments/assets/fd2ef2fe-882c-4e16-ad6c-52510ec24726" />

* FAQ

<img width="1410" height="314" alt="image" src="https://github.com/user-attachments/assets/dd4e9795-5fb9-4cd6-ba4e-9b4336c0b399" />

* Remote 

<img width="856" height="504" alt="image" src="https://github.com/user-attachments/assets/76d30b93-9865-4293-ac96-aa2f431a4c3a" />

* Volunteering @ Europython

<img width="892" height="568" alt="image" src="https://github.com/user-attachments/assets/4f1b1944-15a1-42a8-983c-7c908595e545" />

* Sponsor Information

<img width="856" height="144" alt="image" src="https://github.com/user-attachments/assets/1cdb2c82-d256-49fc-93f3-7efbc02dc08a" />

* Accessibility

<img width="892" height="180" alt="image" src="https://github.com/user-attachments/assets/585d3ea7-4aad-467d-9120-7eafc2d85c3f" />