### PR TITLE
Fix broken link to Prague USEIT Map

### DIFF
--- a/src/content/pages/prague.mdx
+++ b/src/content/pages/prague.mdx
@@ -55,7 +55,7 @@ Prague offers countless activities. Here are just a few ideas:
 - [Timeout](https://www.timeout.com/prague)
 - [My Prague - Insiders' Guide (audio)](https://english.radio.cz/node/8702571/o-poradu)
 - [Honest Guide (videos)](https://www.youtube.com/@HONESTGUIDE)
-- [USEIT Prague Map](https://www.use-it.travel/cities/detail/prague/)
+- [USEIT Prague Map](https://www.use-it.travel/cities/prague/)
 - [Prague Tourist Information](https://praguetouristinformation.com/en/)
 - [Prague.org](https://prague.org/)
 


### PR DESCRIPTION
`https://www.use-it.travel/cities/detail/prague/` seems to be broken, the correct working link is `https://www.use-it.travel/cities/prague/` 

<!-- readthedocs-preview ep-website start -->
🖼️ Preview available 🖼️ : https://ep-website--1445.org.readthedocs.build/
<!-- readthedocs-preview ep-website end -->