### PR TITLE
Improve sprints time and location information

### DIFF
--- a/src/content/pages/sprints_info.md
+++ b/src/content/pages/sprints_info.md
@@ -21,6 +21,15 @@ together.
 
 ![Sprints photos collage](/images/sprints.png)
 
+## When and Where?
+
+The sprints will take place on Saturday and Sunday, 19-20 July.
+Doors open at 8:30 AM, Sprints start at 9:00 AM, Sprints end at 06:00 PM.
+
+The sprints venue is the WPP Prague, located in Ogilvy+ Geometry Business Centre, Bubenská 1, 170 00 Praha 7-Holešovice
+
+<Map location="WPP Prague, Bubenská 1, 170 00 Praha 7-Holešovice" title="Sprints Venue" />
+
 ## Who Can Attend:
 
 - EuroPython ticket holders (Conference, Tutorial, or Combined) can join the

--- a/src/content/pages/sprints_info.md
+++ b/src/content/pages/sprints_info.md
@@ -23,10 +23,11 @@ together.
 
 ## When and Where?
 
-The sprints will take place on Saturday and Sunday, 19-20 July.
-Doors open at 8:30 AM, Sprints start at 9:00 AM, Sprints end at 06:00 PM.
+The sprints will take place on Saturday and Sunday, 19-20 July. Doors open at
+8:30 AM, Sprints start at 9:00 AM, Sprints end at 06:00 PM.
 
-The sprints will be held at the [WPP Prague](/venue/#sprints-venue--saturday--sunday).
+The sprints will be held at the
+[WPP Prague](/venue/#sprints-venue--saturday--sunday).
 
 ## Who Can Attend:
 

--- a/src/content/pages/sprints_info.md
+++ b/src/content/pages/sprints_info.md
@@ -26,9 +26,7 @@ together.
 The sprints will take place on Saturday and Sunday, 19-20 July.
 Doors open at 8:30 AM, Sprints start at 9:00 AM, Sprints end at 06:00 PM.
 
-The sprints venue is the WPP Prague, located in Ogilvy+ Geometry Business Centre, Bubenská 1, 170 00 Praha 7-Holešovice
-
-<Map location="WPP Prague, Bubenská 1, 170 00 Praha 7-Holešovice" title="Sprints Venue" />
+The sprints will be held at the [WPP Prague](/venue/#sprints-venue--saturday--sunday).
 
 ## Who Can Attend:
 

--- a/src/content/pages/venue.mdx
+++ b/src/content/pages/venue.mdx
@@ -28,7 +28,6 @@ Address: 5. května 1640/65, 140 21 Praha 4, Nusle
 ---
 
 ## Sprints Venue – Saturday & Sunday
-### Where
 The EuroPython [Sprints](/sprints) on Saturday & Sunday **19–20 July**, along with the [Beginners' Day](/beginners-day) on Saturday **19 July**, will be held at a **different venue**:
 
 Address: WPP Prague located in Ogilvy+ Geometry Business Centre, Bubenská 1, 170 00 Praha 7-Holešovice

--- a/src/content/pages/venue.mdx
+++ b/src/content/pages/venue.mdx
@@ -29,7 +29,7 @@ Address: 5. května 1640/65, 140 21 Praha 4, Nusle
 
 ## Sprints Venue – Saturday & Sunday
 ### Where
-The EuroPython sprints  on Saturday & Sunday **19–20 July**, along with the Unconference day, Humble Data, and Django Girls, will be held at a **different venue**:
+The EuroPython [Sprints](/sprints) on Saturday & Sunday **19–20 July**, along with the [Beginners' Day](/beginners-day) on Saturday **19 July**, will be held at a **different venue**:
 
 Address: WPP Prague located in Ogilvy+ Geometry Business Centre, Bubenská 1, 170 00 Praha 7-Holešovice
 


### PR DESCRIPTION
### `/sprints`
Add section "When and where?"
<img width="698" height="225" alt="image" src="https://github.com/user-attachments/assets/2a0ab03f-eac2-4465-b88c-6d51a84c7c1f" />

### `/venue/#sprints-venue--saturday--sunday`
* Remove redundant 'Where" header
* Add references to `/sprints` and `/beginners-day`
* Change wording to make references feel less awkward

Before:
<img width="701" height="261" alt="image" src="https://github.com/user-attachments/assets/d3b166b7-2670-4fc6-8221-05f0e4017589" />

After:
<img width="692" height="162" alt="image" src="https://github.com/user-attachments/assets/5dbf6ce6-a642-4567-854b-a4eb0e7fd5e1" />

