### PR TITLE
Expand scope of Apache Arrow sprint

### DIFF
--- a/src/content/sprints/apache_arrow.md
+++ b/src/content/sprints/apache_arrow.md
@@ -6,12 +6,16 @@ contactPerson:
   name: "Rok Mihevc"
   email: "rok.mihevc@gmail.com"
 links:
-  - title: "Apache Arrow"
-    url: "https://github.com/apache/arrow"
+  - title: "List of good first time PyArrow contributor issues"
+    url: "https://github.com/apache/arrow/issues?q=is%3Aissue%20state%3Aopen%20label%3Agood-first-issue%20label%3A%22Component%3A%20Python%22"
+  - title: "Python development guide"
+    url: "https://arrow.apache.org/docs/developers/python.html"
+  - title: "C++ development guide"
+    url: "https://arrow.apache.org/docs/developers/cpp/index.html"
   - title: "Proposed donation of pyarrow-stubs"
     url: "https://github.com/apache/arrow/discussions/45919"
 ---
 
-We want to add type annotations to the PyArrow project. We will sprint to
-identify best approach to do so by prototyping. Suggestions and discussion also
-welcome.
+If there's a feature you want, documentation that you could improve, a bug that bothers you or if you'd just like to open your first PR for PyArrow come join us (Alenka and Rok) and we'll help you pick an issue and open a PR.
+
+Additionally - we want to add type annotations to the PyArrow project. We will sprint to identify best approach to do so by prototyping. Suggestions and discussion also welcome.

--- a/src/content/sprints/apache_arrow.md
+++ b/src/content/sprints/apache_arrow.md
@@ -16,6 +16,10 @@ links:
     url: "https://github.com/apache/arrow/discussions/45919"
 ---
 
-If there's a feature you want, documentation that you could improve, a bug that bothers you or if you'd just like to open your first PR for PyArrow come join us (Alenka and Rok) and we'll help you pick an issue and open a PR.
+If there's a feature you want, documentation that you could improve, a bug that
+bothers you or if you'd just like to open your first PR for PyArrow come join us
+(Alenka and Rok) and we'll help you pick an issue and open a PR.
 
-Additionally - we want to add type annotations to the PyArrow project. We will sprint to identify best approach to do so by prototyping. Suggestions and discussion also welcome.
+Additionally - we want to add type annotations to the PyArrow project. We will
+sprint to identify best approach to do so by prototyping. Suggestions and
+discussion also welcome.


### PR DESCRIPTION
There seems to be interest, so we'd like to propose a slightly different sprint.

<!-- readthedocs-preview ep-website start -->
🖼️ Preview available 🖼️ : https://ep-website--1468.org.readthedocs.build/
<!-- readthedocs-preview ep-website end -->