### PR TITLE
bugfix: sponsor packages page now has the same width as other pages

### DIFF
--- a/src/content/config.ts
+++ b/src/content/config.ts
@@ -11,6 +11,7 @@ const pages = defineCollection({
     title: z.string(),
     subtitle: z.string(),
     toc: z.boolean().optional().default(true),
+    full: z.boolean().optional().default(false),
   }),
 });
 

--- a/src/content/pages/sponsorship/sponsor.mdx
+++ b/src/content/pages/sponsorship/sponsor.mdx
@@ -5,6 +5,7 @@ subtitle:
   and the opportunity to present yourself and your company to one
   of the largest and most diverse Python communities in Europe and beyond.
 toc: false
+full: true
 ---
 
 # Why Sponsor EuroPython?

--- a/src/pages/[...slug].astro
+++ b/src/pages/[...slug].astro
@@ -64,7 +64,7 @@ const description = post.data.subtitle;
 ---
 
 <Layout title={title} description={description} toc={post.data.toc}>
-  <Prose class="pb-20">
+  <Prose class="pb-20" full={post.data.full}>
     <Content
       components={{
         Button,


### PR DESCRIPTION
Previously, the sponsor packages page (`/sponsorship/sponsor/`) was not the same width as all other content pages (it was narrower and looked odd when navigating between pages).

This was due to `MarkdownLayout` having different default styling than `SectionLayout`, the latter of which is used for most pages.

I have fixed it by adding a `full` parameter to the frontmatter which is then handled in `MarkdownLayout` via `[...slug].astro` to allow pages to be full width. The `sponsor.mdx` page was updated with `full: true`.

# Screenshots

## Before

<img width="2958" height="2196" alt="CleanShot 2026-03-09 at 05 18 16@2x" src="https://github.com/user-attachments/assets/670f6278-610b-443d-b2db-4ceacd4d9e5e" />

## After

<img width="2956" height="2300" alt="CleanShot 2026-03-09 at 05 18 34@2x" src="https://github.com/user-attachments/assets/48ca0eb8-33ed-4765-87ba-68faf644bb66" />

# Mobile

Designed / layout is unchanged on mobile.

<!-- readthedocs-preview ep-website start -->
🖼️ Preview available 🖼️ : https://ep-website--1529.org.readthedocs.build/
<!-- readthedocs-preview ep-website end -->