### PR TITLE
Revert "bugfix: sponsor packages page now has the same width as other pages"

### DIFF
--- a/src/content/config.ts
+++ b/src/content/config.ts
@@ -11,7 +11,6 @@ const pages = defineCollection({
     title: z.string(),
     subtitle: z.string(),
     toc: z.boolean().optional().default(true),
-    full: z.boolean().optional().default(false),
   }),
 });
 

--- a/src/content/pages/sponsorship/sponsor.mdx
+++ b/src/content/pages/sponsorship/sponsor.mdx
@@ -5,7 +5,6 @@ subtitle:
   and the opportunity to present yourself and your company to one
   of the largest and most diverse Python communities in Europe and beyond.
 toc: false
-full: true
 ---
 
 # Why Sponsor EuroPython?

--- a/src/pages/[...slug].astro
+++ b/src/pages/[...slug].astro
@@ -64,7 +64,7 @@ const description = post.data.subtitle;
 ---
 
 <Layout title={title} description={description} toc={post.data.toc}>
-  <Prose class="pb-20" full={post.data.full}>
+  <Prose class="pb-20">
     <Content
       components={{
         Button,


### PR DESCRIPTION
Reverts EuroPython/website#1529 

I realized, after merging, that the narrow width was intentional - it's the same design as for the tickets page, so let's have it rather narrow, since the content was designed around it. 
Discussed with Andrew in a DM. 