### PR TITLE
Community partner enable links

### DIFF
--- a/src/components/SponsorCard.astro
+++ b/src/components/SponsorCard.astro
@@ -5,7 +5,7 @@ import { sponsorLogos } from "@data/sponsorLogos";
 import Icon from "@ui/Icon.astro";
 import SocialLinks from "@components/SocialLinks.astro";
 
-const { sponsor: sponsorId, showJobs=false } = Astro.props;
+const { sponsor: sponsorId, showJobs=false, showLinks=true } = Astro.props;
 const sponsor = await getEntry("sponsors", sponsorId);
 
 if (!sponsor) {
@@ -116,7 +116,7 @@ const logo = sponsorLogos[sponsor.id];
         )}
 
 
-      { (tier !== "Partners") &&
+      { (tier !== "Partners" || showLinks) &&
         <SocialLinks socials={socials} />
       }
     </div>

--- a/src/components/SponsorCard.astro
+++ b/src/components/SponsorCard.astro
@@ -100,7 +100,7 @@ const logo = sponsorLogos[sponsor.id];
   }
     <div>
 
-        {(tier !== "Partners") && website && (
+        {website && (
           <div class="website-btn-container flex flex-col sm:flex-row justify-center gap-2 mt-4">
 
             { !isSponsorPage && sponsor.body && tier && ["Diamond", "Platinum"].includes(tier) &&


### PR DESCRIPTION
fixes https://github.com/EuroPython/website/issues/1545

- URL: removed the tier !== 'Partners' restriction entirely as displaying the official website should be a baseline feature for all partners and sponsors.
- Social links: Added an OR gate (tier !== 'Partners' || showLinks) to bypass the current restriction for Community Partners.
Note: I chose an an override for the socials rather than removing the tier restriction altogether to avoid any unintended side effects. We can consider removing the tier-based logic entirely in a future cleanup.