### PR TITLE
Add Language Summit page

### DIFF
--- a/src/content/pages/language-summit.mdx
+++ b/src/content/pages/language-summit.mdx
@@ -11,8 +11,8 @@ subtitle: The Python Language Summit is an event for the developers of Python im
 <b>Where</b>: ICE Kraków Congress Centre, room TBA<br />
 <b>Co-chairs</b>: Emily Morehouse, Hugo van Kemenade, Lysandros Nikolaou, Łukasz Langa<br />
 <b>Blogger</b>: Seth Michael Larson<br />
-<b>Request to attend</b>: httpforms.gle/qCQg3CAfmL6zYkoZ6 (closes Monday, 25th May AoE)<br />
-<b>Submit a topic to present and discuss</b>: forms.gle/nqqc1nMxMjatmD4TA (closes Monday, 25th May AoE)<br />
+<b>Request to attend</b>: https://forms.gle/qCQg3CAfmL6zYkoZ6 (closes Monday, 25th May AoE)<br />
+<b>Submit a topic to present and discuss</b>: https://forms.gle/nqqc1nMxMjatmD4TA (closes Monday, 25th May AoE)<br />
 <b>Invitations confirmed by</b>: Monday, 1st June<br />
 
 ## What is the Language Summit?

--- a/src/content/pages/language-summit.mdx
+++ b/src/content/pages/language-summit.mdx
@@ -11,8 +11,8 @@ subtitle: The Python Language Summit is an event for the developers of Python im
 <b>Where</b>: ICE Kraków Congress Centre, room TBA<br />
 <b>Co-chairs</b>: Emily Morehouse, Hugo van Kemenade, Lysandros Nikolaou, Łukasz Langa<br />
 <b>Blogger</b>: Seth Michael Larson<br />
-<b>Request to attend</b>: TODO form link (closes Monday, 25th May AoE)<br />
-<b>Submit a topic to present and discuss</b>: TODO form link (closes Monday, 25th May AoE)<br />
+<b>Request to attend</b>: httpforms.gle/qCQg3CAfmL6zYkoZ6 (closes Monday, 25th May AoE)<br />
+<b>Submit a topic to present and discuss</b>: forms.gle/nqqc1nMxMjatmD4TA (closes Monday, 25th May AoE)<br />
 <b>Invitations confirmed by</b>: Monday, 1st June<br />
 
 ## What is the Language Summit?
@@ -27,7 +27,7 @@ We welcome Python core team and triage team members, active contributors to CPyt
 
 ## Who can propose a discussion topic
 
-If you have discussion items; seeking consensus; awaiting community feedback on a PEP; need help with your core work; or have specific questions that need answers from the core team, please [submit a proposal](TODO form link). According to feedback, our audience prefers more discussions and shorter talks.
+If you have discussion items; seeking consensus; awaiting community feedback on a PEP; need help with your core work; or have specific questions that need answers from the core team, please [submit a proposal](https://forms.gle/nqqc1nMxMjatmD4TA). According to feedback, our audience prefers more discussions and shorter talks.
 
 In your proposal, please include the following:
 

--- a/src/content/pages/language-summit.mdx
+++ b/src/content/pages/language-summit.mdx
@@ -1,6 +1,6 @@
 ---
 title: Language Summit
-subtitle: Discuss the future of the Python language
+subtitle: The Python Language Summit is an event for the developers of Python implementations (CPython, PyPy, MicroPython, GraalPython, IronPython, and so on) to share information, discuss our shared problems, and — hopefully — solve them.
 ---
 
 # Language Summit

--- a/src/content/pages/language-summit.mdx
+++ b/src/content/pages/language-summit.mdx
@@ -27,7 +27,7 @@ We welcome Python core team and triage team members, active contributors to CPyt
 
 ## Who can propose a discussion topic
 
-If you have discussion items; seeking consensus; awaiting community feedback on a PEP; need help with your core work; or have specific questions that need answers from the core team, please submit a proposal. According to feedback, our audience prefers more discussions and shorter talks.
+If you have discussion items; seeking consensus; awaiting community feedback on a PEP; need help with your core work; or have specific questions that need answers from the core team, please [submit a proposal](TODO form link). According to feedback, our audience prefers more discussions and shorter talks.
 
 In your proposal, please include the following:
 
@@ -62,7 +62,7 @@ No, there will be no recording and no live stream available. If you'd like to pa
 
 ## I need to ask a private question
 
-Sure thing! You can message the organizers privately [on Discourse](https://discuss.python.org/) and we’ll get you sorted.
+Sure thing! You can message the organizers privately [on Discourse](https://discuss.python.org/) or the core team Discord and we’ll get you sorted.
 
 ## We hope you have a great event!
 

--- a/src/content/pages/language-summit.mdx
+++ b/src/content/pages/language-summit.mdx
@@ -1,0 +1,70 @@
+---
+title: Language Summit
+subtitle: Discuss the future of the Python language
+---
+
+# Language Summit
+
+## TL;DR
+
+<b>When</b>: Tuesday, 14 July at 9:00am<br />
+<b>Where</b>: ICE Kraków Congress Centre, room TBA<br />
+<b>Co-chairs</b>: Emily Morehouse, Hugo van Kemenade, Lysandros Nikolaou, Łukasz Langa<br />
+<b>Blogger</b>: Seth Michael Larson<br />
+<b>Request to attend</b>: TODO form link (closes Monday, 25th May AoE)<br />
+<b>Submit a topic to present and discuss</b>: TODO form link (closes Monday, 25th May AoE)<br />
+<b>Invitations confirmed by</b>: Monday, 1st June<br />
+
+## What is the Language Summit?
+
+The Python Language Summit is an event for the developers of Python implementations (CPython, PyPy, MicroPython, GraalPython, IronPython, and so on) to share information, discuss our shared problems, and — hopefully — solve them.
+
+These issues might be related to the language itself, the standard library, the development process, the status of Python 3.15 (and plans for 3.16), the documentation, packaging, the website, and so forth. The Summit focuses on discussions and consensus-seeking, more than merely on presentations.
+
+## Who can attend
+
+We welcome Python core team and triage team members, active contributors to CPython and alternative Python implementations, and other community members with a topic to discuss with the core team.
+
+## Who can propose a discussion topic
+
+If you have discussion items; seeking consensus; awaiting community feedback on a PEP; need help with your core work; or have specific questions that need answers from the core team, please submit a proposal. According to feedback, our audience prefers more discussions and shorter talks.
+
+In your proposal, please include the following:
+
+- why is this topic relevant to the core team;
+- what is needed from the core team out of this topic.
+
+## Can I come if I don't sign up?
+
+Sorry, no. This is an invite-only event with limited capacity at the venue. After you sign up, we will let you know before 1st June if you're invited.
+
+## Do I need to sign up if I’m a Python core team member?
+
+Yes, please! We have limited space, and we want to avoid overcrowding. Please register to reserve your space.
+
+## Can I sign up if I’m not a core developer of a Python implementation?
+
+Yes, you can. In the past, we had quite a number of participants who were not core contributors to CPython or other implementations of Python. Among them were maintainers and representatives from BeeWare, CircuitPython, PyCharm, PSF board members, PyO3 and PyPA.
+
+Some of them have since joined the Python core team, so that's a risk you must be willing to accept when signing up.
+
+## Do I need to be registered to EuroPython to attend the Language Summit?
+
+Yes, this is so that you receive a badge and catering during the day. Core team members can apply for a free ticket via the [Guido van Rossum Core Developer Grant](https://www.europython-society.org/core-grant/). If you only want to attend the Language Summit portion and not the rest of the conference, then we can provide you with a voucher that allows you to be registered at EuroPython. This way you'll be in the system. However, we do recommend that you be registered for the full EuroPython. There are amazing talks and keynotes on the schedule that you wouldn't want to miss.
+
+## How can I learn what's happening at the event?
+
+A detailed summary of the event will be published on the [Python Software Foundation blog](https://pyfound.blogspot.com/). Just like last year, the event will be covered by Seth Michael Larson, the Security Developer in Residence at the Python Software Foundation.
+
+## Is this event recorded? Can I watch a live stream?
+
+No, there will be no recording and no live stream available. If you'd like to participate in discussions, please sign up to attend. If you'd like to listen in, please wait for Seth’s blog posts after the Summit.
+
+## I need to ask a private question
+
+Sure thing! You can message the organizers privately [on Discourse](https://discuss.python.org/) and we’ll get you sorted.
+
+## We hope you have a great event!
+
+Your Language Summit cat herding team,<br />
+Emily Morehouse-Valcarcel, Hugo van Kemenade, Lysandros Nikolaou & Łukasz Langa

--- a/src/data/enabledPages.json
+++ b/src/data/enabledPages.json
@@ -22,6 +22,7 @@
     "/visa",
     "/about",
     "/faq",
+    "/language-summit",
     "/sponsorship/sponsor",
     "/sponsorship/information",
     "/tickets"

--- a/src/data/links.json
+++ b/src/data/links.json
@@ -18,6 +18,15 @@
       ]
     },
     {
+      "name": "Events",
+      "items": [
+        {
+          "name": "Language Summit",
+          "path": "/language-summit"
+        }
+      ]
+    },
+    {
       "name": "Venue",
       "items": [
         {

--- a/src/data/links.json
+++ b/src/data/links.json
@@ -139,6 +139,15 @@
       ]
     },
     {
+      "name": "Events",
+      "items": [
+        {
+          "name": "Language Summit",
+          "path": "/language-summit"
+        }
+      ]
+    },
+    {
       "name": "Sponsorship",
       "items": [
         {


### PR DESCRIPTION
Draft for now, we'll add the signup form links soon.

https://language-summit.ep-preview.click/language-summit/