### PR TITLE
Mention ticket types for Langauge Summit

### DIFF
--- a/src/content/pages/language-summit.mdx
+++ b/src/content/pages/language-summit.mdx
@@ -50,7 +50,7 @@ Some of them have since joined the Python core team, so that's a risk you must b
 
 ## Do I need to be registered to EuroPython to attend the Language Summit?
 
-Yes, this is so that you receive a badge and catering during the day. Core team members can apply for a free ticket via the [Guido van Rossum Core Developer Grant](https://www.europython-society.org/core-grant/). If you only want to attend the Language Summit portion and not the rest of the conference, then we can provide you with a voucher that allows you to be registered at EuroPython. This way you'll be in the system. However, we do recommend that you be registered for the full EuroPython. There are amazing talks and keynotes on the schedule that you wouldn't want to miss.
+Yes, this is so that you receive a badge and catering during the day. Any of a Tutorials, Conference, or Combined ticket will do. Core team members can apply for a free ticket via the [Guido van Rossum Core Developer Grant](https://www.europython-society.org/core-grant/). If you only want to attend the Language Summit portion and not the rest of the conference, then we can provide you with a voucher that allows you to be registered at EuroPython. This way you'll be in the system. However, we do recommend that you be registered for the full EuroPython. There are amazing talks and keynotes on the schedule that you wouldn't want to miss.
 
 ## How can I learn what's happening at the event?
 


### PR DESCRIPTION
Explicitly say "Any of a Tutorials, Conference, or Combined ticket will do."

And we also have a fallback to a voucher already in there.