### PR TITLE
update available sponsor slots

### DIFF
--- a/src/components/sponsor-tiers/sponsor-tiers.astro
+++ b/src/components/sponsor-tiers/sponsor-tiers.astro
@@ -12,6 +12,7 @@ const { signupLink = "#" } = Astro.props;
 interface SponsorTierProps {
   title: string;
   slotsLeft?: number | null | string;
+  totalSlots?: number | null;
   price: number | string;
   features: string[];
 }
@@ -30,6 +31,7 @@ const tiers: SponsorTierProps[] = [
   {
     title: "Diamond",
     slotsLeft: 1,
+    totalSlots: 2,
     price: 30_000,
     features: [
       "<strong>Extra large</strong> booth in exhibit hall (incl. TV & stand)",
@@ -60,6 +62,7 @@ const tiers: SponsorTierProps[] = [
   {
     title: "Platinum",
     slotsLeft: 1,
+    totalSlots: 4,
     price: 18_000,
     features: [
       "<strong>Large</strong> booth in exhibit hall <strong>(incl. TV & stand)</strong>",
@@ -87,6 +90,7 @@ const tiers: SponsorTierProps[] = [
     title: "Gold",
     price: 9_500,
     slotsLeft: 0,
+    totalSlots: 10,
     features: [
       "Booth in exhibit hall",
       "<strong>3</strong> conference tickets (€1500 value)",
@@ -106,6 +110,7 @@ const tiers: SponsorTierProps[] = [
     title: "Silver",
     price: 7_000,
     slotsLeft: 0,
+    totalSlots: 10,
     features: [
       "Small booth in exhibit hall",
       "2 conference tickets (€1000 value)",
@@ -217,13 +222,19 @@ const formatPrice = (price: number | string) => {
               <Headline as="h3" title={tier.title} />
               <div class="font-bold text-3xl">{formatPrice(tier.price)}</div>
               <div class="text-xl mt-4">
-                {tier.slotsLeft ? (
-                  <>
-                    <span>{tier.slotsLeft}</span>
-                    {tier.slotsLeft == 1 ? "slot" : "slots"} available
-                  </>
+                {typeof tier.slotsLeft === "number" ? (
+                  tier.totalSlots ? (
+                    <>
+                      {tier.slotsLeft} out of {tier.totalSlots}{" "}
+                      {tier.totalSlots === 1 ? "slot" : "slots"} available
+                    </>
+                  ) : (
+                    <>
+                      {tier.slotsLeft} slot{tier.slotsLeft === 1 ? "" : "s"} available
+                    </>
+                  )
                 ) : (
-                  <>Fully booked</>
+                  <>{tier.slotsLeft}</>
                 )}
               </div>
             </div>
@@ -319,17 +330,19 @@ const formatPrice = (price: number | string) => {
               <Headline as="h3" title={tier.title} />
               <div class="font-bold text-3xl">{formatPrice(tier.price)}</div>
               <div class="text-xl">
-                {tier.slotsLeft === "Exclusive" ? (
-                  <>Exclusive</>
-                ) : tier.slotsLeft === "Talk to us" ? (
-                  <>Talk to us</>
-                ) : tier.slotsLeft ? (
-                  <>
-                    <span>{tier.slotsLeft}</span>
-                    {tier.slotsLeft == 1 ? "slot" : "slots"} available
-                  </>
+                {typeof tier.slotsLeft === "number" ? (
+                  tier.totalSlots ? (
+                    <>
+                      {tier.slotsLeft} out of {tier.totalSlots}{" "}
+                      {tier.totalSlots === 1 ? "slot" : "slots"} available
+                    </>
+                  ) : (
+                    <>
+                      {tier.slotsLeft} slot{tier.slotsLeft === 1 ? "" : "s"} available
+                    </>
+                  )
                 ) : (
-                  <>Fully booked</>
+                  <>{tier.slotsLeft}</>
                 )}
               </div>
             </div>
@@ -377,13 +390,13 @@ const formatPrice = (price: number | string) => {
               <Headline as="h3" title={tier.title} />
               <div class="font-bold text-3xl">{formatPrice(tier.price)}</div>
               <div class="text-xl">
-                {tier.slotsLeft ? (
+                {typeof tier.slotsLeft === "number" ? (
                   <>
                     <span>{tier.slotsLeft}</span>
                     {tier.slotsLeft == 1 ? "slot" : "slots"} available
                   </>
                 ) : (
-                  <>Fully booked</>
+                  <>{tier.slotsLeft}</>
                 )}
               </div>
             </div>

--- a/src/components/sponsor-tiers/sponsor-tiers.astro
+++ b/src/components/sponsor-tiers/sponsor-tiers.astro
@@ -29,7 +29,7 @@ const tiers: SponsorTierProps[] = [
   },
   {
     title: "Diamond",
-    slotsLeft: 2,
+    slotsLeft: 1,
     price: 30_000,
     features: [
       "<strong>Extra large</strong> booth in exhibit hall (incl. TV & stand)",
@@ -59,7 +59,7 @@ const tiers: SponsorTierProps[] = [
   },
   {
     title: "Platinum",
-    slotsLeft: 4,
+    slotsLeft: 1,
     price: 18_000,
     features: [
       "<strong>Large</strong> booth in exhibit hall <strong>(incl. TV & stand)</strong>",
@@ -86,7 +86,7 @@ const tiers: SponsorTierProps[] = [
   {
     title: "Gold",
     price: 9_500,
-    slotsLeft: 10,
+    slotsLeft: 0,
     features: [
       "Booth in exhibit hall",
       "<strong>3</strong> conference tickets (€1500 value)",
@@ -105,7 +105,7 @@ const tiers: SponsorTierProps[] = [
   {
     title: "Silver",
     price: 7_000,
-    slotsLeft: 10,
+    slotsLeft: 0,
     features: [
       "Small booth in exhibit hall",
       "2 conference tickets (€1000 value)",

--- a/src/content/pages/sponsorship/sponsor.mdx
+++ b/src/content/pages/sponsorship/sponsor.mdx
@@ -51,6 +51,14 @@ supporting the Python community is accessible for organisations of all sizes.
 <Button class="m-2" url="https://drive.google.com/file/d/1w-jRonxRbSzIYlsDwolOv3YUYWauPe5y/view">Full Sponsorship Opportunities (PDF)</Button>
 <Button class="m-2" url="https://forms.gle/YsBUuwKQ3LJPjsET8">Sign up now!</Button>
 
+<Note>
+  <span className="block text-2xl font-semibold mb-3">Most sponsor packages with exhibition booths are now sold out </span>
+
+  <span className="block  mb-3">However, we still have a limited number of <strong>sponsorship packages available without a booth</strong>, including Platinum, Gold, and Silver boothless options.</span>
+
+  <span className="block">Please contact <a href="mailto:sponsoring@europython.eu">sponsoring@europython.eu</a> if you are interested, and we’d be happy to discuss the available options!</span>
+</Note>
+
 <SponsorTiers signupLink="https://forms.gle/YsBUuwKQ3LJPjsET8" />
 
 ## Optional Add-ons
@@ -59,7 +67,7 @@ Alongside our main sponsorship packages, we offer **premium optional add-ons**
 designed to amplify your sponsorship impact and visibility.
 Available for **Silver Package level and above**, some popular examples include:
 
-- **Technical Talk Slot (30 min)**: €5000
+- ~~**[Sold Out] Technical Talk Slot (30 min)**: €5000~~
 - **Tutorial/Workshop Slot (3h)**: €5000
 - **Poster slot**: €3000
 - **Open Space Sponsor**: €2000
@@ -73,7 +81,7 @@ Available for **Silver Package level and above**, some popular examples include:
 We also offer opportunities for
 <span class="font-semibold">Financial Aid Sponsor</span> –
 <span class="font-semibold">Social Event Sponsor</span> –
-<span class="font-semibold">PyLadies Lunch Sponsor</span> –
+~~<span class="font-semibold">[Sold Out] PyLadies Lunch Sponsor</span>~~ –
 <span class="font-semibold">Speaker Dinner Sponsor</span> –
 <span class="font-semibold">Plenary Room Sponsor</span> –
 <span class="font-semibold">Quiet Room Sponsor</span> –


### PR DESCRIPTION
Simplified the way to handle slotLeft a little.
- totalSlots is now an integer (where applicable, not used for Patron and Bronze)
- slotsLeft behaves as follows:
  - If it is a number, it renders as “X out of Y slots available”
  - If it is a string, it renders directly as provided (e.g. "Exclusive", "Fully booked", "Yearning for Dogs", etc)