### PR TITLE
Remove broken /childcare link

### DIFF
--- a/src/content/pages/tickets.mdx
+++ b/src/content/pages/tickets.mdx
@@ -115,7 +115,7 @@ If you're purchasing multiple tickets, please consider sponsoring the event!
       <span>☕ Every ticket includes break refreshments and a light lunch for each day.</span>
     </li>
     <li class="flex items-start">
-      <span>👶 Free childcare is available at the conference for children aged 19 months and older. For more info, check out our [childcare](/childcare) page. Please make sure to register a ticket for yourself and select how many children will require childcare at checkout.</span>
+      <span>👶 Free childcare is available at the conference for children aged 19 months and older. Please make sure to register a ticket for yourself and select how many children will require childcare at checkout.</span>
     </li>
     <li class="flex items-start">
       <span>⏰ We encourage you to book your ticket early. This makes it easier for us to plan for the event and arrange important things like catering, badge printing, and other logistics.</span>


### PR DESCRIPTION
As requested by @anezkamll on Discord: The `/childcare` site does not yet exist, so let's not link to it. The childcare details will be added later.