### PR TITLE
Add dedicated EuroSciPy section to homepage

### DIFF
--- a/src/components/BaseHead.astro
+++ b/src/components/BaseHead.astro
@@ -16,6 +16,9 @@ const { title, description, image = "/social-card.png" } = Astro.props;
 <meta charset="utf-8" />
 <meta name="viewport" content="width=device-width,initial-scale=1" />
 <link rel="icon" type="image/svg+xml" href="/eps-logo.svg" />
+<link rel="preconnect" href="https://fonts.googleapis.com" />
+<link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+<link href="https://fonts.googleapis.com/css2?family=Archivo+Black&family=DM+Sans:opsz,wght@9..40,400;9..40,600;9..40,700&display=swap" rel="stylesheet" />
 <meta name="generator" content="Astro" />
 <meta name="build-version" content={gitVersion} />
 <meta name="build-timestamp" content={buildTimestamp} />

--- a/src/components/sections/euroscipy.astro
+++ b/src/components/sections/euroscipy.astro
@@ -15,7 +15,7 @@ import Button from "@ui/Button.astro";
     </div>
 
     <div class="euroscipy-right">
-      <p>EuroSciPy is Europe's premier conference on scientific Python — covering NumPy, SciPy, pandas, machine learning, and the broader scientific ecosystem. In 2026 it comes to Kraków, right after EuroPython.</p>
+      <p>The EuroSciPy meeting is a cross-disciplinary gathering focused on the use and development of the Python language in scientific research. This event strives to bring together both users and developers of scientific tools, as well as academic research and state of the art industry.</p>
       <p><strong>We co-organise the sprints together.</strong> The final two days of EuroPython sprints overlap with the opening of EuroSciPy sprints — giving you the unique opportunity to hack alongside both communities at once.</p>
       <div class="euroscipy-sprint-badge">✦ Joint sprints: 18–19 July</div>
     </div>

--- a/src/components/sections/euroscipy.astro
+++ b/src/components/sections/euroscipy.astro
@@ -1,0 +1,171 @@
+---
+import Button from "@ui/Button.astro";
+---
+
+<section class="sec-wrap euroscipy-section" id="euroscipy">
+  <div class="sec-inner split-layout euroscipy-inner">
+
+    <div class="split-left euroscipy-left">
+      <h2 class="sec-title euroscipy-title">EuroSciPy 2026 <sup class="sec-anchor"><a href="#euroscipy">#</a></sup></h2>
+      <div class="euroscipy-dates">
+        18–23 July 2026<br>
+        AGH University of Kraków, Poland
+      </div>
+      <a href="https://euroscipy.org" class="euroscipy-cta">Get Your Ticket</a>
+    </div>
+
+    <div class="euroscipy-right">
+      <p>EuroSciPy is Europe's premier conference on scientific Python — covering NumPy, SciPy, pandas, machine learning, and the broader scientific ecosystem. In 2026 it comes to Kraków, right after EuroPython.</p>
+      <p><strong>We co-organise the sprints together.</strong> The final two days of EuroPython sprints overlap with the opening of EuroSciPy sprints — giving you the unique opportunity to hack alongside both communities at once.</p>
+      <div class="euroscipy-sprint-badge">✦ Joint sprints: 20–21 July</div>
+    </div>
+
+  </div>
+</section>
+
+<style>
+  .sec-wrap {
+    color: var(--color-white, #fff);
+    position: relative;
+    overflow: hidden;
+  }
+
+  .euroscipy-section {
+    background: var(--color-euroscipy, #2e2ed4);
+    scroll-margin-top: 60px;
+  }
+
+  .sec-inner {
+    max-width: 1200px;
+    margin: 0 auto;
+    padding: 4.5rem 2rem;
+    position: relative;
+    z-index: 1;
+  }
+
+  .split-layout {
+    display: grid;
+    grid-template-columns: 1fr 1fr;
+    gap: 4rem;
+    align-items: start;
+  }
+
+  .split-left {
+    position: sticky;
+    top: 2rem;
+  }
+
+  @media (max-width: 768px) {
+    .split-layout {
+      grid-template-columns: 1fr;
+      gap: 2rem;
+    }
+    .split-left {
+      position: static;
+    }
+    .sec-inner {
+      padding: 3rem 1.5rem;
+    }
+  }
+
+  /* ---- Title ---- */
+  .sec-title {
+    font-family: var(--font-archivo, 'Archivo Black', sans-serif);
+    font-size: clamp(2.8rem, 5vw, 4.5rem);
+    line-height: 1.05;
+    letter-spacing: -0.02em;
+    color: var(--color-white, #fff);
+    text-transform: uppercase;
+    margin-bottom: 0;
+    position: relative;
+  }
+
+  .euroscipy-title {
+    font-size: clamp(2.8rem, 5vw, 4.2rem);
+    line-height: 1;
+    margin-bottom: 0.6rem;
+  }
+
+  .euroscipy-title .sec-anchor {
+    font-size: 0.5em;
+    vertical-align: super;
+    margin-left: 0.2em;
+    opacity: 0;
+    transition: opacity 0.2s ease;
+  }
+
+  .euroscipy-title:hover .sec-anchor {
+    opacity: 0.5;
+  }
+
+  .euroscipy-title .sec-anchor a {
+    color: var(--color-white, #fff);
+    text-decoration: none;
+  }
+
+  .euroscipy-title .sec-anchor a:hover {
+    opacity: 0.8;
+  }
+
+  /* ---- Dates ---- */
+  .euroscipy-dates {
+    font-family: 'DM Sans', system-ui, sans-serif;
+    font-size: 1.25rem;
+    color: rgba(255, 255, 255, 0.78);
+    line-height: 1.6;
+    margin-bottom: 2rem;
+  }
+
+  /* ---- CTA ---- */
+  .euroscipy-cta {
+    display: inline-block;
+    font-size: 1.15rem;
+    padding: 0.85rem 2.2rem;
+    background: linear-gradient(to bottom, #f04040, #cc3030);
+    color: var(--color-white, #fff);
+    border: 1px solid #f04040;
+    border-radius: 0.375rem;
+    font-weight: 700;
+    text-decoration: none;
+    transition: filter 0.2s ease;
+    cursor: pointer;
+  }
+
+  .euroscipy-cta:hover {
+    filter: brightness(1.1);
+  }
+
+  /* ---- Right column ---- */
+  .euroscipy-right {
+    display: flex;
+    flex-direction: column;
+    gap: 1.2rem;
+  }
+
+  .euroscipy-right p {
+    font-family: 'DM Sans', system-ui, sans-serif;
+    font-size: 1.15rem;
+    color: rgba(255, 255, 255, 0.93);
+    line-height: 1.65;
+    margin: 0;
+  }
+
+  .euroscipy-right p strong {
+    color: var(--color-white, #fff);
+  }
+
+  /* ---- Sprint badge ---- */
+  .euroscipy-sprint-badge {
+    display: inline-flex;
+    align-items: center;
+    gap: 0.5rem;
+    background: rgba(255, 255, 255, 0.10);
+    border: 1px dashed rgba(255, 255, 255, 0.25);
+    border-radius: 2px;
+    padding: 0.5rem 1.2rem;
+    font-family: 'DM Sans', system-ui, sans-serif;
+    font-weight: 700;
+    font-size: 1rem;
+    color: var(--color-white, #fff);
+  }
+</style>

--- a/src/components/sections/euroscipy.astro
+++ b/src/components/sections/euroscipy.astro
@@ -17,7 +17,7 @@ import Button from "@ui/Button.astro";
     <div class="euroscipy-right">
       <p>EuroSciPy is Europe's premier conference on scientific Python — covering NumPy, SciPy, pandas, machine learning, and the broader scientific ecosystem. In 2026 it comes to Kraków, right after EuroPython.</p>
       <p><strong>We co-organise the sprints together.</strong> The final two days of EuroPython sprints overlap with the opening of EuroSciPy sprints — giving you the unique opportunity to hack alongside both communities at once.</p>
-      <div class="euroscipy-sprint-badge">✦ Joint sprints: 20–21 July</div>
+      <div class="euroscipy-sprint-badge">✦ Joint sprints: 18–19 July</div>
     </div>
 
   </div>

--- a/src/components/sections/history.astro
+++ b/src/components/sections/history.astro
@@ -19,13 +19,5 @@ import Section from "../ui/Section.astro";
       tutorials, and sprints.
     </p>
 
-    <div class="mt-12 pt-8 border-t border-gray-200">
-      <h3 class="text-2xl md:text-3xl font-semibold mb-6">That's not everything!</h3>
-      <p>
-        <strong>EuroSciPy</strong> is also coming to Kraków! From <strong>July 18-24, 2026</strong>, the scientific Python community
-        will gather in the same beautiful city. Both conferences will feature <strong>shared sprints</strong>, offering a unique opportunity
-        to collaborate across the broader Python ecosystem and connect with both general Python developers and scientific computing specialists.
-      </p>
-    </div>
   </div>
 </Section>

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -11,6 +11,7 @@ import "../styles/bg-universe.css";
 // import City from "@sections/city.astro";
 import Sponsors from "@sections/sponsors/sponsors.astro";
 import Testimonials from "@sections/testimonials.astro";
+import EuroSciPy from "@sections/euroscipy.astro";
 import CommunityPartners from "@sections/community-partners.astro";
 import Subscribe from "@sections/subscribe.astro";
 ---
@@ -23,6 +24,7 @@ import Subscribe from "@sections/subscribe.astro";
     <Hero />
     <History />
     <!-- <Week /> -->
+    <EuroSciPy />
     <Updates />
   </div>
   <KrakowGallery />

--- a/src/styles/tailwind.css
+++ b/src/styles/tailwind.css
@@ -37,6 +37,9 @@
   --color-secondary-darkest: #ffffff;
   --color-secondary-light: #7a7ebd;
 
+  /* Section Colors */
+  --color-euroscipy: #2e2ed4;
+
   /* Hero Colors */
   --color-hero-primary: #151f38;
   --color-hero-secondary: #fabc1b;
@@ -64,6 +67,9 @@
 
   /* Font Families */
   --font-system: system-ui, sans-serif;
+  --font-archivo: "Archivo Black", sans-serif;
+  --font-dm-sans: "DM Sans", system-ui, sans-serif;
+
   --font-title:
     -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, Helvetica, Arial,
     sans-serif, "Apple Color Emoji", "Segoe UI Emoji", "Segoe UI Symbol";


### PR DESCRIPTION
Adds a dedicated EuroSciPy section to the homepage, modelled after the existing design in the Django template. Features a split two-column layout with conference details, a CTA button, and a joint-sprints badge.

The section uses the same typography (Archivo Black and DM Sans) and brand colours consistent with the EuroSciPy identity. Duplicate inline mention of EuroSciPy in the history section has been removed.