### PR TITLE
Remove period after talk title

### DIFF
--- a/src/pages/api/media/combined_socials_queue.ts
+++ b/src/pages/api/media/combined_socials_queue.ts
@@ -71,18 +71,18 @@ const speakerMessageTemplate = {
     `Join ${name} at EuroPython for "${talkTitle}".`,
   x: ({ name, handle, talkTitle, talkUrl }) =>
     handle
-      ? `Join ${name} (${handle}) at EuroPython for "${talkTitle}". Talk: ${talkUrl}`
-      : `Join ${name} at EuroPython for "${talkTitle}". Talk: ${talkUrl}`,
+      ? `Join ${name} (${handle}) at EuroPython for "${talkTitle}" talk: ${talkUrl}`
+      : `Join ${name} at EuroPython for "${talkTitle}" talk: ${talkUrl}`,
   linkedin: ({ name, talkTitle }) =>
     `Join ${name} at EuroPython for "${talkTitle}".`,
   bsky: ({ name, handle, talkTitle, talkUrl }) =>
     handle
-      ? `Join ${name} (${handle}) at EuroPython for "${talkTitle}". Talk: ${talkUrl}`
-      : `Join ${name} at EuroPython for "${talkTitle}". Talk: ${talkUrl}`,
+      ? `Join ${name} (${handle}) at EuroPython for "${talkTitle}" talk: ${talkUrl}`
+      : `Join ${name} at EuroPython for "${talkTitle}" talk: ${talkUrl}`,
   fosstodon: ({ name, handle, talkTitle, talkUrl }) =>
     handle
-      ? `Join ${name} (${handle}) at EuroPython for "${talkTitle}". talk: ${talkUrl}`
-      : `Join ${name} at EuroPython for "${talkTitle}". Talk: ${talkUrl}`,
+      ? `Join ${name} (${handle}) at EuroPython for "${talkTitle}" talk: ${talkUrl}`
+      : `Join ${name} at EuroPython for "${talkTitle}" talk: ${talkUrl}`,
 };
 
 // Sponsor messages

--- a/src/pages/api/media/speakers/posts.ts
+++ b/src/pages/api/media/speakers/posts.ts
@@ -66,21 +66,21 @@ export const GET: APIRoute = async () => {
 
     x: ({ name, handle, talkTitle, talkUrl }) =>
       handle
-        ? `Join ${name} (${handle}) at EuroPython for "${talkTitle}". Talk: ${talkUrl}`
-        : `Join ${name} at EuroPython for "${talkTitle}". Talk: ${talkUrl}`,
+        ? `Join ${name} (${handle}) at EuroPython for "${talkTitle}" talk: ${talkUrl}`
+        : `Join ${name} at EuroPython for "${talkTitle}" talk: ${talkUrl}`,
 
     linkedin: ({ name, talkTitle }) =>
       `Join ${name} at EuroPython for "${talkTitle}".`,
 
     bsky: ({ name, handle, talkTitle, talkUrl }) =>
       handle
-        ? `Join ${name} (${handle}) at EuroPython for "${talkTitle}". Talk: ${talkUrl}`
-        : `Join ${name} at EuroPython for "${talkTitle}". Talk: ${talkUrl}`,
+        ? `Join ${name} (${handle}) at EuroPython for "${talkTitle}" talk: ${talkUrl}`
+        : `Join ${name} at EuroPython for "${talkTitle}" talk: ${talkUrl}`,
 
     fosstodon: ({ name, handle, talkTitle, talkUrl }) =>
       handle
-        ? `Join ${name} (${handle}) at EuroPython for "${talkTitle}". talk: ${talkUrl}`
-        : `Join ${name} at EuroPython for "${talkTitle}". Talk: ${talkUrl}`,
+        ? `Join ${name} (${handle}) at EuroPython for "${talkTitle}" talk: ${talkUrl}`
+        : `Join ${name} at EuroPython for "${talkTitle}" talk: ${talkUrl}`,
   };
 
   const trimToLimit = (text: string, limit: number) =>


### PR DESCRIPTION
For the first part of https://github.com/EuroPython/website/issues/1611.

Followed by lowercase 'talk'.

Note: I've not tested this.