### PR TITLE
Fix date format on schedule

### DIFF
--- a/src/components/schedule/day.astro
+++ b/src/components/schedule/day.astro
@@ -350,7 +350,7 @@ posters.forEach((poster) => {
 
 
 const date = parseISO(dayName);
-const dateText = format(date, "EEE eeee, MMMM d");
+const dateText = format(date, "eeee d MMMM");
 
 
 


### PR DESCRIPTION
# Before: Wed Wednesday, July 15

<img width="1226" height="257" alt="image" src="https://github.com/user-attachments/assets/260fb080-17ff-4bf8-a826-66b4062a8953" />


https://ep2026.europython.eu/schedule/talks/

# After: Tuesday 14 July

Matches the DD MONTH format of the front page: https://ep2026.europython.eu/

<img width="1229" height="253" alt="image" src="https://github.com/user-attachments/assets/5f2ea936-c752-49f7-9186-e06c84739fdf" />

The wrong day is a timezone bug showing on the local dev server, will fix that separately.
