### PR TITLE
Fix timezone bug for local dev

### DIFF
--- a/src/components/schedule/day.astro
+++ b/src/components/schedule/day.astro
@@ -349,7 +349,7 @@ posters.forEach((poster) => {
 });
 
 
-const date = parseISO(dayName);
+const date = parseISO(`${dayName}T12:00:00Z`);
 const dateText = format(date, "eeee d MMMM");
 
 


### PR DESCRIPTION
I'm in Helsinki, east of UTC.

Presumably the server or GitHub Actions build is using UTC for the prod build.

Using local midnight time means the day calculation is wrong. Use noon UTC instead.


# Prod

<img width="1213" height="268" alt="image" src="https://github.com/user-attachments/assets/0b55dfb2-6fc7-4730-ade1-506f56da9b6c" />

# Local dev before

<img width="1227" height="267" alt="image" src="https://github.com/user-attachments/assets/03b3a6e0-6f54-41c8-8abc-bb77ddb9eff5" />

# Local dev after

<img width="1213" height="268" alt="image" src="https://github.com/user-attachments/assets/0b55dfb2-6fc7-4730-ade1-506f56da9b6c" />

