### PR TITLE
Re-show ❤️s on schedule

### DIFF
--- a/src/components/schedule/session.astro
+++ b/src/components/schedule/session.astro
@@ -1,4 +1,5 @@
 ---
+import CodeHeart from "@components/island/CodeHeart.svelte";
 import Speakers from "./speakers.astro";
 import { slugify } from "@utils/content";
 
@@ -31,6 +32,12 @@ const sessionUrl = session.slug ? `/session/${session.slug}` : "#";
   class:list={["ep-session", session.level, slugify(session.sessionType)]}
   style={style}
 >
+  <CodeHeart
+    client:load
+    mini={true}
+    codeId={session.code}
+    title={session.title}
+  />
   <a href={sessionUrl} class="ep-session-title">{session.title}</a>
 
   {session.speakers && session.speakers.length > 0 && (


### PR DESCRIPTION
After hearting the first keynote:

<img width="994" height="160" alt="image" src="https://github.com/user-attachments/assets/e9796cb5-9888-468b-bf83-71dc29403975" />

Prod:

<img width="1238" height="506" alt="image" src="https://github.com/user-attachments/assets/5b05abd9-ba3a-4505-a14a-c6af31481b70" />

Fix:

<img width="1228" height="524" alt="image" src="https://github.com/user-attachments/assets/e96cf84b-de59-473d-b43d-2819ab2e1821" />
