### PR TITLE
fix: Add missing menu to access schedule for tutorials

### DIFF
--- a/src/data/links.json
+++ b/src/data/links.json
@@ -4,7 +4,11 @@
       "name": "Programme",
       "items": [
         {
-          "name": "Schedule",
+          "name": "Schedule - Tutorials",
+          "path": "/schedule/tutorials"
+        },
+        {
+          "name": "Schedule - Talks",
           "path": "/schedule/talks"
         },
         {
@@ -157,7 +161,11 @@
       "name": "Programme",
       "items": [
         {
-          "name": "Schedule",
+          "name": "Schedule - Tutorials",
+          "path": "/schedule/tutorials"
+        },
+        {
+          "name": "Schedule - Talks",
           "path": "/schedule/talks"
         },
         {


### PR DESCRIPTION


<!-- readthedocs-preview ep-website start -->
🖼️ Preview available 🖼️ : https://ep-website--1657.org.readthedocs.build/
<!-- readthedocs-preview ep-website end -->