### PR TITLE
use theme-aware text colours for location and salary in JobCard

### DIFF
--- a/src/components/JobCard.astro
+++ b/src/components/JobCard.astro
@@ -28,8 +28,8 @@ const { title, location, type, level, salary, description, responsibilities, min
       <h2 class="text-3xl font-bold mb-2">{title}</h2>
     </a>
 
-    <p class="text-white/60 mb-2">{([level, type, location].filter(Boolean)).join(" • ")}</p>
-    <p class="text-white/70 mb-4">{salary}</p>
+    <p class="text-[var(--color-text-muted)] mb-2">{([level, type, location].filter(Boolean)).join(" • ")}</p>
+    <p class="text-[var(--color-text-secondary)] mb-4">{salary}</p>
     <Markdown content={description || ""} class="job-post" />
 
     { responsibilities &&


### PR DESCRIPTION
fixes https://github.com/EuroPython/website/issues/1658

before: 
<img width="534" height="129" alt="image" src="https://github.com/user-attachments/assets/190170a7-7d97-47c2-bfef-5f8766875659" />

after: 
<img width="556" height="118" alt="image" src="https://github.com/user-attachments/assets/e873dfc7-cb8f-413c-b6db-3600bff83ca9" />
