### PR TITLE
Re-order social networks and add TikTok to match footer

### DIFF
--- a/src/components/sections/connect.astro
+++ b/src/components/sections/connect.astro
@@ -24,9 +24,17 @@ import Section2 from "@ui/Section2.astro";
 
       <div class="connect-block">
         <div class="connect-socials">
-          <a href="https://x.com/europython" class="connect-social-link" title="X / Twitter">
-            <i class="fab fa-x-twitter"></i>
-            <span>X</span>
+          <a href="https://linkedin.com/company/europython" class="connect-social-link" title="LinkedIn">
+            <i class="fab fa-linkedin-in"></i>
+            <span>LinkedIn</span>
+          </a>
+          <a href="https://github.com/europython" class="connect-social-link" title="GitHub">
+            <i class="fab fa-github"></i>
+            <span>GitHub</span>
+          </a>
+          <a href="https://youtube.com/channel/UC98CzaYuFNAA_gOINFB0e4Q" class="connect-social-link" title="YouTube">
+            <i class="fab fa-youtube"></i>
+            <span>YouTube</span>
           </a>
           <a href="https://fosstodon.org/@europython" class="connect-social-link" title="Mastodon">
             <i class="fab fa-mastodon"></i>
@@ -36,21 +44,17 @@ import Section2 from "@ui/Section2.astro";
             <i class="fab fa-bluesky"></i>
             <span>Bluesky</span>
           </a>
-          <a href="https://linkedin.com/company/europython" class="connect-social-link" title="LinkedIn">
-            <i class="fab fa-linkedin-in"></i>
-            <span>LinkedIn</span>
-          </a>
           <a href="https://instagram.com/europython" class="connect-social-link" title="Instagram">
             <i class="fab fa-instagram"></i>
             <span>Instagram</span>
           </a>
-          <a href="https://youtube.com/channel/UC98CzaYuFNAA_gOINFB0e4Q" class="connect-social-link" title="YouTube">
-            <i class="fab fa-youtube"></i>
-            <span>YouTube</span>
+          <a href="https://www.tiktok.com/@europython" class="connect-social-link" title="TikTok">
+            <i class="fab fa-tiktok"></i>
+            <span>TikTok</span>
           </a>
-          <a href="https://github.com/europython" class="connect-social-link" title="GitHub">
-            <i class="fab fa-github"></i>
-            <span>GitHub</span>
+          <a href="https://x.com/europython" class="connect-social-link" title="X / Twitter">
+            <i class="fab fa-x-twitter"></i>
+            <span>X</span>
           </a>
         </div>
       </div>


### PR DESCRIPTION
The footer has the social networks in this order:

<img width="1143" height="217" alt="image" src="https://github.com/user-attachments/assets/8b290762-9f26-419b-93bb-adc8d8c8fd8a" />

Let's update the homepage to match, and add missing TikTok.

# Before

<img width="1173" height="563" alt="image" src="https://github.com/user-attachments/assets/4a6ccb37-764a-4ab1-a212-e7a9f4edc288" />

# After

<img width="1156" height="570" alt="image" src="https://github.com/user-attachments/assets/a083cd74-843b-4fe2-94f2-e1ddf97087b7" />
