### PR TITLE
Use session title in breadcrumb instead of converted URL slug

### DIFF
--- a/src/components/Breadcrumbs.astro
+++ b/src/components/Breadcrumbs.astro
@@ -4,6 +4,7 @@ import Section from "@ui/Section.astro";
 export interface Props {
   linksData: any;
   currentPath: string;
+  currentLabel?: string;
   homeLabel?: string;
   homePath?: string;
   separator?: string;
@@ -12,6 +13,7 @@ export interface Props {
 const {
   linksData,
   currentPath,
+  currentLabel,
   homeLabel = "Home",
   homePath = "/",
   separator = "/"
@@ -84,7 +86,7 @@ if (breadcrumbs.length === 1 && normalizedCurrentPath !== normalizePath(homePath
 
   if (lastSegment) {
     breadcrumbs.push({
-      name: lastSegment.replace(/-/g, ' ').replace(/\b\w/g, l => l.toUpperCase()),
+      name: currentLabel ?? lastSegment.replace(/-/g, ' ').replace(/\b\w/g, l => l.toUpperCase()),
       path: currentPath,
       isActive: true
     });

--- a/src/layouts/Layout.astro
+++ b/src/layouts/Layout.astro
@@ -70,6 +70,7 @@ const hideFooter = Astro.props.hideFooter ?? false;
           <Breadcrumbs
               linksData={breadcrumbData}
               currentPath={currentPath}
+              currentLabel={title}
               homePath="/"
               separator="›"
           />


### PR DESCRIPTION
## Before

The URL slug is converted to Title Case, but this messes up consecutive capitals:

> Home > Cpython Panel

https://ep2026.europython.eu/session/cpython-panel/

> Home > Securing Systems In The Age Of Generative Ai

https://ep2026.europython.eu/session/securing-systems-in-the-age-of-generative-ai

It also messes up things which should be title case:

> Home > The Coolest Feature In Python 3 14 Sys Remote Exec

https://ep2026.europython.eu/session/the-coolest-feature-in-python-3-14-sys-remote-exec

## After

Instead, use the title directly:

> Home > CPython Panel

> Home > Securing Systems in the Age of Generative AI

> Home > The coolest feature in Python 3.14: sys.remote_exec()
