### PR TITLE
Schedule: remove confusing diagonal-stripe backgrounds

### DIFF
--- a/src/components/schedule/session.astro
+++ b/src/components/schedule/session.astro
@@ -190,28 +190,4 @@ const sessionUrl = session.slug ? `/session/${session.slug}` : "#";
       font-size: 0.9rem;
     }
   }
-
-  .beginner {
-    background:
-      repeating-linear-gradient(
-        -45deg,
-        transparent,
-        transparent 4px,
-        var(--ep-beginner-stripe) 4px,
-        var(--ep-beginner-stripe) 6px
-      ),
-      var(--ep-surface-subtle);
-  }
-
-  .advanced {
-    background:
-      repeating-linear-gradient(
-        -45deg,
-        transparent,
-        transparent 4px,
-        var(--ep-advanced-stripe) 4px,
-        var(--ep-advanced-stripe) 6px
-      ),
-      var(--ep-surface-subtle);
-  }
 </style>

--- a/src/components/sessions/list-posters.astro
+++ b/src/components/sessions/list-posters.astro
@@ -124,30 +124,6 @@ const { posters } = Astro.props;
       background 0.1s ease-in-out;
   }
 
-  .poster-card.beginner {
-    background:
-      repeating-linear-gradient(
-        -45deg,
-        transparent,
-        transparent 4px,
-        var(--ep-beginner-stripe) 4px,
-        var(--ep-beginner-stripe) 6px
-      ),
-      var(--color-surface-subtle);
-  }
-
-  .poster-card.advanced {
-    background:
-      repeating-linear-gradient(
-        -45deg,
-        transparent,
-        transparent 4px,
-        var(--ep-advanced-stripe) 4px,
-        var(--ep-advanced-stripe) 6px
-      ),
-      var(--color-surface-subtle);
-  }
-
   .poster-title {
     font-family: "Inter Tight", system-ui, sans-serif;
     font-size: 1.25rem;

--- a/src/pages/talks.astro
+++ b/src/pages/talks.astro
@@ -382,30 +382,6 @@ const allDisplayTracks = [...sortedTracks, ...otherTracks];
     z-index: 10;
   }
 
-  .talk-card.beginner {
-    background:
-      repeating-linear-gradient(
-        -45deg,
-        transparent,
-        transparent 4px,
-        var(--ep-beginner-stripe) 4px,
-        var(--ep-beginner-stripe) 6px
-      ),
-      var(--color-surface-subtle);
-  }
-
-  .talk-card.advanced {
-    background:
-      repeating-linear-gradient(
-        -45deg,
-        transparent,
-        transparent 4px,
-        var(--ep-advanced-stripe) 4px,
-        var(--ep-advanced-stripe) 6px
-      ),
-      var(--color-surface-subtle);
-  }
-
   .talk-card-title {
     font-family: "Inter Tight", system-ui, sans-serif;
     font-size: 1.25rem;

--- a/src/pages/tutorials.astro
+++ b/src/pages/tutorials.astro
@@ -241,30 +241,6 @@ const tutorials = allSessions
     z-index: 10;
   }
 
-  .tutorial-card.beginner {
-    background:
-      repeating-linear-gradient(
-        -45deg,
-        transparent,
-        transparent 4px,
-        var(--ep-beginner-stripe) 4px,
-        var(--ep-beginner-stripe) 6px
-      ),
-      var(--color-surface-subtle);
-  }
-
-  .tutorial-card.advanced {
-    background:
-      repeating-linear-gradient(
-        -45deg,
-        transparent,
-        transparent 4px,
-        var(--ep-advanced-stripe) 4px,
-        var(--ep-advanced-stripe) 6px
-      ),
-      var(--color-surface-subtle);
-  }
-
   .tutorial-card-title {
     font-family: "Inter Tight", system-ui, sans-serif;
     font-size: 1.25rem;

--- a/src/styles/ep2026-theme.css
+++ b/src/styles/ep2026-theme.css
@@ -47,8 +47,6 @@
      light-theme.css). These flip so the schedule chrome matches the
      active theme instead of staying navy/dark in light mode. */
   --ep-session-hover-bg: oklch(0.24 0.05 266.4); /* #0f1a2e */
-  --ep-beginner-stripe: oklch(0.66 0.18 145 / 0.2); /* rgba(50,180,50,.2) */
-  --ep-advanced-stripe: oklch(0.55 0.18 25 / 0.2); /* rgba(200,50,50,.2) */
   --ep-break-bg: oklch(0.75 0.15 70 / 0.06); /* rgba(255,150,0,.06) */
   --ep-break-border: oklch(0.75 0.15 70 / 0.18); /* rgba(255,150,0,.18) */
   --ep-day-end-bg: oklch(0.34 0.03 266); /* #2d3548 */
@@ -258,31 +256,6 @@ body.ep2026-theme {
   outline: 2px solid var(--ep-accent);
   outline-offset: 2px;
   border-radius: 6px;
-}
-
-/* Session levels */
-.ep-session.beginner {
-  background:
-    repeating-linear-gradient(
-      -45deg,
-      transparent,
-      transparent 4px,
-      var(--ep-beginner-stripe) 4px,
-      var(--ep-beginner-stripe) 6px
-    ),
-    var(--ep-surface-subtle);
-}
-
-.ep-session.advanced {
-  background:
-    repeating-linear-gradient(
-      -45deg,
-      transparent,
-      transparent 4px,
-      var(--ep-advanced-stripe) 4px,
-      var(--ep-advanced-stripe) 6px
-    ),
-    var(--ep-surface-subtle);
 }
 
 /* Breaks */

--- a/src/styles/light-theme.css
+++ b/src/styles/light-theme.css
@@ -23,11 +23,6 @@
   --ep-sched-chrome-bg: oklch(0.945 0.004 264); /* #e6e8ed */
   --ep-sched-chrome-text: oklch(0 0 0 / 0.55);
 
-  /* Session level stripes: lighter, lower-alpha on light cards so the
-     diagonal hatch stays subtle instead of heavy. */
-  --ep-beginner-stripe: oklch(0.72 0.17 145 / 0.12);
-  --ep-advanced-stripe: oklch(0.6 0.2 25 / 0.1);
-
   /* Session level pills — light theme: SOLID pastel chips (no
      opacity). High lightness + low chroma backgrounds with darker
      ink of the same hue for readable, low-saturation labels. */


### PR DESCRIPTION
The diagonal stripes on the schedule are confusing and make the schedule harder to read:

<img width="1148" height="568" alt="image" src="https://github.com/user-attachments/assets/34843546-621c-4156-a5d1-84435cb23520" />

https://ep2026.europython.eu/schedule/#day-2026-07-15

There's no key, and I didn't know what they meant before I looked at the code:

* green diagonal stripes: beginner level
* red diagonal stripes: advanced level

We already have explicit Beginner/Intermediate/Advanced labels on each session, let's remove the diagonals:

<img width="1138" height="566" alt="image" src="https://github.com/user-attachments/assets/309e624c-92fd-4aef-8738-c93689757663" />
