### PR TITLE
Schedule: sort rooms with S-number first

### DIFF
--- a/src/components/schedule/day.astro
+++ b/src/components/schedule/day.astro
@@ -37,7 +37,8 @@ const dayName = day.id;
 //const day = getEntry("days", dayName);
 
 const getRoomSortKey = (room: string) => {
-  const match = room.match(/\(S(\d+)([A-Z]?)\)/i);
+  // rooms without an S-number ("Glass room", "Fishbowl") sort last
+  const match = room.match(/^S(\d+)([A-Z]?)$/i);
 
   if (!match) {
     return `99-${room}`;

--- a/src/components/schedule/day.astro
+++ b/src/components/schedule/day.astro
@@ -36,21 +36,31 @@ const { day } = Astro.props;
 const dayName = day.id;
 //const day = getEntry("days", dayName);
 
+// Predefined display order; rooms not listed here sort last, alphabetically.
+const ROOM_ORDER = [
+  "S1",
+  "S2",
+  "S3A",
+  "S3B",
+  "S4",
+  "S4A",
+  "S4B",
+  "Glass room",
+  "2.017/2.018",
+  "Fishbowl",
+  "Exhibit Hall",
+];
+
 const getRoomSortKey = (room: string) => {
-  // rooms without an S-number ("Glass room", "Fishbowl") sort last
-  const match = room.match(/^S(\d+)([A-Z]?)$/i);
-
-  if (!match) {
-    return `99-${room}`;
-  }
-
-  const [, number, suffix = ""] = match;
-  return `${number.padStart(2, "0")}-${suffix || "0"}-${room}`;
+  const index = ROOM_ORDER.indexOf(room);
+  return index === -1 ? ROOM_ORDER.length : index;
 };
 
 const ROOMS = (day.data.rooms ?? [])
   .filter((room) => room.toLowerCase() !== "exhibit hall")
-  .sort((a, b) => getRoomSortKey(a).localeCompare(getRoomSortKey(b)));
+  .sort(
+    (a, b) => getRoomSortKey(a) - getRoomSortKey(b) || a.localeCompare(b),
+  );
 
 type ScheduleSession = {
   title: string;


### PR DESCRIPTION
Wednesday looks like:
<img width="1227" height="768" alt="image" src="https://github.com/user-attachments/assets/1080a557-890f-48de-a2f6-409452ebf0f1" />

But when you go to Thursday or Friday, suddenly "Glass Room" appears and moves the keynotes to the right:

<img width="1188" height="819" alt="image" src="https://github.com/user-attachments/assets/ec4057bc-a1c8-4b76-9088-9d4f78e0e2e0" />

Instead, sort rooms without an S-number ("Glass room", "Fishbowl") last:

<img width="1188" height="767" alt="image" src="https://github.com/user-attachments/assets/e83e38c3-5518-45b5-aece-2af9850fe26a" />

---

This also means Monday/Tuesday change from summits then tutorials:

<img width="1179" height="792" alt="image" src="https://github.com/user-attachments/assets/8a7f6cc5-10e0-46e2-a22c-4693b91cca75" />

To tutorials then summits:

<img width="1185" height="748" alt="image" src="https://github.com/user-attachments/assets/c1aa4a0f-e06e-4f17-a409-9f047d74bfef" />

But I think that's fine.