### PR TITLE
Schedule: remove polka dot background

### DIFF
--- a/src/styles/ep2026-theme.css
+++ b/src/styles/ep2026-theme.css
@@ -107,18 +107,13 @@ body.ep2026-theme {
 
 /* Schedule section wrapper */
 .ep-sched-section {
-  background:
-    radial-gradient(circle, var(--ep-surface-medium) 1px, transparent 1px),
-    linear-gradient(
-      135deg,
-      var(--ep-footer-g1) 0%,
-      var(--ep-footer-g2) 40%,
-      var(--ep-footer-g3) 70%,
-      var(--ep-footer-g4) 100%
-    );
-  background-size:
-    24px 24px,
-    100% 100%;
+  background: linear-gradient(
+    135deg,
+    var(--ep-footer-g1) 0%,
+    var(--ep-footer-g2) 40%,
+    var(--ep-footer-g3) 70%,
+    var(--ep-footer-g4) 100%
+  );
   color: var(--ep-white);
 }
 


### PR DESCRIPTION
Similar to https://github.com/EuroPython/website/pull/1738, the dotted background makes the schedule harder to read:

<img width="1458" height="815" alt="image" src="https://github.com/user-attachments/assets/6db41397-90f1-4702-8db5-3fd393e2b8c7" />

Let's remove the dots:

<img width="1465" height="824" alt="image" src="https://github.com/user-attachments/assets/ed7d4c92-a959-4c8b-98ad-150f43a0be2f" />
