### PR TITLE
Allow wider schedule

### DIFF
--- a/src/layouts/ScheduleLayout.astro
+++ b/src/layouts/ScheduleLayout.astro
@@ -27,7 +27,7 @@ const { title, description, headline } = Astro.props;
 
   <div class="ep-sched-section">
     <div class="ep-sched-inner">
-      <Section>
+      <Section full>
         <h1 class="ep-headline" id={slugify(headline)}>
           <a href={`#${slugify(headline)}`} aria-label={`Jump to ${headline}`}
             >{headline}</a

--- a/src/styles/ep2026-theme.css
+++ b/src/styles/ep2026-theme.css
@@ -116,7 +116,7 @@ body.ep2026-theme {
 }
 
 .ep-sched-inner {
-  max-width: 1400px;
+  max-width: 1800px;
   margin: 0 auto;
   padding: 2rem 1.5rem;
 }


### PR DESCRIPTION
Let's use more of the available screen width to show the schedule.

Before:

<img width="1582" height="1031" alt="image" src="https://github.com/user-attachments/assets/6bf71e45-8b66-4a93-a7af-d91a9893cbcd" />

After:

<img width="1582" height="1031" alt="image" src="https://github.com/user-attachments/assets/7f408e57-ddaf-448c-a964-40023d96b31a" />
