### PR TITLE
2025: Add header to link to latest EuroPython

### DIFF
--- a/src/components/Header.astro
+++ b/src/components/Header.astro
@@ -11,6 +11,7 @@ import links from "@data/links.json";
 <section
   id="navbar"
 >
+<a href="https://europython.eu/" class="bg-secondary text-white hover:text-white hover:underline text-center px-2 font-bold fixed top-0 w-full h-[40px] z-50 flex items-center justify-center">This is the website for an older EuroPython. Looking for the latest EuroPython? Click here!</a>
   <div
     class="container max-w-[1150px] mx-auto px-6 py-2 mt-12 lg:p-2 lg:mt-14 flex items-center justify-between relative z-40 bg-white/80 rounded-full backdrop-blur-md shadow-lg"
   >

--- a/src/content/sponsors/travelperk/index.md
+++ b/src/content/sponsors/travelperk/index.md
@@ -35,7 +35,8 @@ design.
 Founded in 2015 and headquartered in Barcelona, we've grown to over 1,400 people
 across Europe and North America. In 2022 we became a 'unicorn' and in 2025 we
 raised $200 million in a Series E funding round, increasing our valuation of
-$2.7 billion
+$2.7
+billion
 [](https://www.travelperk.com/blog/travelperk-acquires-yokoy/?utm_campaign=Oktopost-Corporate%20Announcements&utm_content=Oktopost-LinkedIn&utm_medium=social&utm_source=LinkedIn).
 
 We've been winning awards too. Since 2023, we've been voted one of the


### PR DESCRIPTION
Similar to https://ep2023.europython.eu/ and https://ep2024.europython.eu/, add a header to https://ep2025.europython.eu/:

> [This is the website for an older EuroPython. Looking for the latest EuroPython? Click here!](https://europython.eu/)

Note, https://ep2025.europython.eu/ still has this banner:

> [Can’t join us in Prague? Attend remotely — online options available!](https://ep2025.europython.eu/remote)

But the code was already removed in https://github.com/EuroPython/website/pull/1484, so still needs deploying.
