### PR TITLE
Use h1 for page titles to improve a11y, SEO, site search

### DIFF
--- a/src/components/ui/Title.astro
+++ b/src/components/ui/Title.astro
@@ -4,6 +4,7 @@ export interface Props {
   subtitle?: string;
   color?: string; // title text color, default #fff
   anchorColor?: string; // anchor link color, default matches color
+  as?: "h1" | "h2"; // h1 when the Title is the page's main heading
 }
 
 const {
@@ -11,10 +12,11 @@ const {
   subtitle,
   color = "var(--color-text)",
   anchorColor = color,
+  as: Tag = "h2",
 } = Astro.props;
 ---
 
-<h2 class="sec-title" style={`color: ${color}`}>
+<Tag class="sec-title" style={`color: ${color}`}>
   <slot />
   <sup class="sec-anchor"
     ><a
@@ -23,7 +25,7 @@ const {
       aria-label={`Jump to ${id}`}>#</a
     ></sup
   >
-</h2>
+</Tag>
 {
   subtitle && (
     <p class="sec-subtitle" style={`color: var(--color-text-muted)`}>

--- a/src/pages/posters.astro
+++ b/src/pages/posters.astro
@@ -26,6 +26,7 @@ const posters = allSessions
       <div class="text-center mb-12">
         <Title
           id="posters"
+          as="h1"
           subtitle="A visual showcase of projects, research, and ideas — presented in person during a dedicated poster session."
         >
           POSTERS

--- a/src/pages/sessions.astro
+++ b/src/pages/sessions.astro
@@ -33,7 +33,7 @@ const description = "A list of all the sessions at the conference";
 
 <Layout title={title} description={description}>
   <Section2 id="sessions">
-    <Title id="sessions">List of Sessions</Title>
+    <Title id="sessions" as="h1">List of Sessions</Title>
     <Prose full>
       <p>Here you can find a list of all the sessions at the conference.</p>
       <p>You can filter the sessions by track, type, and level.</p>

--- a/src/pages/speaker/[slug].astro
+++ b/src/pages/speaker/[slug].astro
@@ -85,7 +85,7 @@ function getGitHosting(url: string): string | undefined {
 
 <Layout title={entry.data.name} description={`Profile of ${entry.data.name}`}>
   <Section2 variant="dark" id="speaker-page">
-    <Title id="speaker">{entry.data.name}</Title>
+    <Title id="speaker" as="h1">{entry.data.name}</Title>
 
     <div class="md:grid grid-cols-[460px_1fr] md:gap-6">
       {

--- a/src/pages/speakers.astro
+++ b/src/pages/speakers.astro
@@ -16,6 +16,7 @@ const sortedSpeakers = speakers
     <div class="section-header">
       <Title
         id="all-speakers"
+        as="h1"
         subtitle={`${sortedSpeakers.length} speakers at EuroPython 2026`}
         >All Speakers</Title
       >

--- a/src/pages/talks.astro
+++ b/src/pages/talks.astro
@@ -80,6 +80,7 @@ const allDisplayTracks = [...sortedTracks, ...otherTracks];
       <div class="text-center mb-12">
         <Title
           id="talks"
+          as="h1"
           subtitle="The heart of EuroPython — three days of talks across five parallel tracks, covering every corner of the Python ecosystem."
         >
           TALKS

--- a/src/pages/tutorials.astro
+++ b/src/pages/tutorials.astro
@@ -44,6 +44,7 @@ const tutorials = allSessions
       <div class="text-center mb-12">
         <Title
           id="tutorials"
+          as="h1"
           subtitle="Full-day, hands-on workshops led by domain experts. Go deeper than any talk can — bring your laptop and leave with real skills."
         >
           TUTORIALS


### PR DESCRIPTION
Some pages uses h2 for titles, when the top-level should be h1.

I spotted some search results had "undefined" headers:

<img width="695" height="782" alt="image" src="https://github.com/user-attachments/assets/1d103a98-abe0-4bd6-b419-aa1f35102952" />

This is because Pagefind uses the h1 for the title by default.

Using a single h1 header also helps accessibility -- screen readers benefit from being able to semantically find the main page header -- and SEO.

`src/components/ui/Title.astro` is used for some pages that should have an h1 header, but also for in places which should remain as h2, such as homepage sections such as `sections/krakow.astro`. So it's h2 by default, and is explicitly set to h1 where needed.