### PR TITLE
Fix PyLadies session links

### DIFF
--- a/src/content/pages/pyladies/index.mdx
+++ b/src/content/pages/pyladies/index.mdx
@@ -50,8 +50,8 @@ Finally, we will use interactive machine learning to define a personalised way o
 
 - **Location:** Glass Room (Ground Floor)
 - **Time:** Thursday 16th of July
-- **Speaker:** [Anna Wszeborowska](https://ep2026.europython.eu/speaker/anna-wszeborowska/)
-- **View in the schedule:** [Create your own musical instrument with custom gesture control](https://ep2026.europython.eu/session/create-your-own-musical-instrument-with-custom-gesture-control)
+- **Speaker:** [Anna Wszeborowska](/speaker/anna-wszeborowska/)
+- **View in the schedule:** [Create your own musical instrument with custom gesture control](/session/create-your-own-musical-instrument-with-custom-gesture-control)
 
 ### Leading Under Pressure
 Teams are getting leaner, context switching is constant, and expectations stay high even when clarity is low. Under that pressure, many of us start reacting instead of leading: stepping in too often, firefighting instead of thinking, and quietly carrying load that was never ours to hold.
@@ -62,8 +62,8 @@ This workshop is a space to notice what pressure does to your leadership, and to
 
 - **Location:** Glass Room (Ground Floor)
 - **Time:** Thursday 16th of July
-- **Speaker:** [Tereza Iofciu](https://ep2026.europython.eu/speaker/tereza-iofciu/)
-- **View in the schedule:** [Leading Under Pressure](https://ep2026.europython.eu/session/leading-under-pressure)
+- **Speaker:** [Tereza Iofciu](/speaker/tereza-iofciu/)
+- **View in the schedule:** [Leading Under Pressure](/session/leading-under-pressure)
 
 ## PyLadies Lunch
 

--- a/src/content/pages/pyladies/index.mdx
+++ b/src/content/pages/pyladies/index.mdx
@@ -51,7 +51,7 @@ Finally, we will use interactive machine learning to define a personalised way o
 - **Location:** Glass Room (Ground Floor)
 - **Time:** Thursday 16th of July
 - **Speaker:** [Anna Wszeborowska](https://ep2026.europython.eu/speaker/anna-wszeborowska/)
-- **View in the schedule:** https://ep2026.europython.eu/session/create-your-own-musical-instrument-with-custom-gesture-control
+- **View in the schedule:** [Create your own musical instrument with custom gesture control](https://ep2026.europython.eu/session/create-your-own-musical-instrument-with-custom-gesture-control)
 
 ### Leading Under Pressure
 Teams are getting leaner, context switching is constant, and expectations stay high even when clarity is low. Under that pressure, many of us start reacting instead of leading: stepping in too often, firefighting instead of thinking, and quietly carrying load that was never ours to hold.
@@ -63,7 +63,7 @@ This workshop is a space to notice what pressure does to your leadership, and to
 - **Location:** Glass Room (Ground Floor)
 - **Time:** Thursday 16th of July
 - **Speaker:** [Tereza Iofciu](https://ep2026.europython.eu/speaker/tereza-iofciu/)
-- **View in the schedule:** https://ep2026.europython.eu/session/leading-under-pressure
+- **View in the schedule:** [Leading Under Pressure](https://ep2026.europython.eu/session/leading-under-pressure)
 
 ## PyLadies Lunch
 


### PR DESCRIPTION
https://ep2026.europython.eu/pyladies/ shows unlinked links:

<img width="707" height="217" alt="image" src="https://github.com/user-attachments/assets/f1914068-383a-4d18-a6a2-52d6458a2d88" />
<img width="742" height="201" alt="image" src="https://github.com/user-attachments/assets/dbb409f0-54c4-402a-b7c6-372fa3eb0f3a" />

Seems the old Astro 5 did autolink these, but the new Astro 6 upgrade from https://github.com/EuroPython/website/pull/1649 no longer does so.

I can't find any other affected links.

(A good reason to hold off the Astro 6->7 in https://github.com/EuroPython/website/pull/1758 :)
