### PR TITLE
Show posters when printing the schedule

### DIFF
--- a/src/layouts/ScheduleLayout.astro
+++ b/src/layouts/ScheduleLayout.astro
@@ -520,7 +520,11 @@ const showNoticeGrid = !Astro.url.pathname.match(/^\/schedule\/?$/);
     }
 
     .ep-session,
-    .break {
+    .time,
+    .break,
+    .lunch-break,
+    .posters-inside,
+    .sched-lunch-events {
       break-inside: avoid;
     }
 
@@ -584,18 +588,100 @@ const showNoticeGrid = !Astro.url.pathname.match(/^\/schedule\/?$/);
       padding: 1pt 4pt !important;
     }
 
-    /* Lunch slot: show the "13:00 Lunch" bar, skip the poster cards
-     (they have their own page at /schedule/day/…) */
+    /* Lunch slot: show header bar + poster cards + side events */
     .lunch-break-header {
       display: block !important;
       font-size: 8pt !important;
       padding: 2pt !important;
-      border-bottom: none !important;
+      border-bottom: 1px solid #ccc !important;
       background: transparent !important;
     }
 
     .lunch-break-content {
-      display: none !important;
+      display: block !important;
+      background: transparent !important;
+    }
+
+    .lunch-break-content .posters-inside h2 {
+      font-size: 8pt !important;
+      font-weight: 700 !important;
+      margin: 0 !important;
+      padding: 3pt 2pt !important;
+      border-bottom: 1px solid #ccc !important;
+    }
+
+    .lunch-break-content .poster-cards {
+      display: flex !important;
+      flex-wrap: wrap !important;
+    }
+
+    .lunch-break-content .poster-cards > div {
+      flex: 1 1 200px !important;
+      max-width: 250px !important;
+    }
+
+    .lunch-break-content .ep-session.poster {
+      display: flex !important;
+      padding: 2pt 3pt !important;
+      margin: 1pt !important;
+      border: 1px solid #ccc !important;
+      border-radius: 2px !important;
+      background: oklch(0 0 0 / 0.03) !important;
+    }
+
+    .lunch-break-content .ep-session.poster .ep-session-title {
+      font-size: 7pt !important;
+      line-height: 1.2 !important;
+    }
+
+    .lunch-break-content .ep-session.poster .ep-session-speakers {
+      font-size: 6.5pt !important;
+    }
+
+    .lunch-break-content .ep-session.poster .ep-session-meta {
+      font-size: 6pt !important;
+    }
+
+    .lunch-break-content .sched-lunch-hr {
+      display: block !important;
+      border: none !important;
+      border-top: 1px solid #ccc !important;
+      margin: 4pt 0 !important;
+    }
+
+    .lunch-break-content .sched-lunch-events {
+      display: block !important;
+      padding: 2pt !important;
+    }
+
+    .lunch-break-content .sched-lunch-events-label {
+      font-size: 7pt !important;
+      font-weight: 600 !important;
+      margin-bottom: 2pt !important;
+    }
+
+    .lunch-break-content .sched-posters-list {
+      display: flex !important;
+      flex-wrap: wrap !important;
+      justify-content: center !important;
+      gap: 2pt 6pt !important;
+      list-style: none !important;
+      margin: 0 !important;
+      padding: 0 !important;
+    }
+
+    .lunch-break-content .sched-posters-list li {
+      font-size: 6.5pt !important;
+    }
+
+    .lunch-break-content .sched-posters-list a {
+      display: inline-block !important;
+      border: 1px solid #ccc !important;
+      border-radius: 3px !important;
+      padding: 2pt 6pt !important;
+      color: oklch(0.522 0.218 264.4) !important;
+      text-decoration: none !important;
+      font-size: 6.5pt !important;
     }
   }
 </style>


### PR DESCRIPTION
Poster sessions were hidden when printing because `.lunch-break-content { display: none !important; }` in the `@media print` block suppressed the entire lunch content area.

### Changes

In `ScheduleLayout.astro` / `@media print`:

- **Remove** `display: none` from `.lunch-break-content`  
- **Add** compact print styles for poster cards inside the lunch slot:
  - Poster cards use the existing `.ep-session.poster` component at 7pt
  - Side events (PyLadies Lunch, Communities Lunch) rendered as a compact list
  - All headed by the "13:00 Lunch" bar with a visible border separator
- Poster badge (which says "Poster" on the card) stays hidden in print (already gated by `@media (min-width: 800px)` which matches A4 landscape)

### Before / After

| Element | Before (print) | After (print) |
|---------|---------------|---------------|
| Lunch header | "13:00 Lunch" | "13:00 Lunch" |
| Poster cards | ❌ Hidden | ✅ Compact cards with title + speakers |
| Side event links | ❌ Hidden | ✅ Compact list |
| Session grid | ✅ Works | ✅ Works |