### PR TITLE
Update open spaces calendar information

### DIFF
--- a/src/content/pages/open-spaces.mdx
+++ b/src/content/pages/open-spaces.mdx
@@ -19,16 +19,14 @@ them most.
 
 Open Spaces are participant-driven gatherings where anyone can propose a topic,
 lead a discussion or presentation, and collaborate with others. Attendees can
-add their session idea to the Open Spaces registration calendar, which also
+add their session idea to the Open Spaces registration calendar below, which also
 serves to attract potential participants interested in joining.
-
-Check out the [schedule](/schedule/#day-2026-07-15) to see the Open Spaces!
 
 ## How to Organise an Open Space
 
 Rooms S4(1,2,3), S4(4), and S4(5) will be reserved exclusively for Open Space
 sessions. To organise your own Open Space, simply book a free time slot and room
-using the links below:
+using the links below, and your session will appear on the calendar shortly:
 
 [Room S4(1,2,3)](https://calendar.app.google/t7MHRuVLYRkJXtAK7) | [Room S4(4)](https://calendar.app.google/Phw2NBXTyqjj8Lwt6)
 | [Room S4(5)](https://calendar.app.google/JjtSSNgxnxeUTASt7)


### PR DESCRIPTION
The location of the open spaces calendar changed, so I updated the page accordingly:
- Removed the line that pointed to the talks schedule
- Added line saying that the sessions will appear in this calendar

<!-- readthedocs-preview ep-website start -->
🖼️ Preview available 🖼️ : https://ep-website--1801.org.readthedocs.build/
<!-- readthedocs-preview ep-website end -->