### PR TITLE
Add topics in the Community Organisers Summit page

### DIFF
--- a/src/content/pages/community-organisers-summit/index.mdx
+++ b/src/content/pages/community-organisers-summit/index.mdx
@@ -22,6 +22,11 @@ It begins with a **short introduction**, setting the stage for the day’s activ
 
 From there, the summit moves into **facilitated small group discussions**, where participants explore topics related to organizing Python events and communities. These sessions are designed to encourage in-depth conversation, knowledge sharing, and exchange of real-world experiences.
 
+The **discussion topics** are:
+- **Sponsorships** facilitated by **Kshitijaa Jaglan**
+- **Diversity & Inclusion Challenges** facilitated by **Naa Ashiorkor**
+- **Sustainability in the AI Era** facilitated by **Ege Akman**
+
 Each group will then come back together for **short presentations**, sharing key insights, discussion points, and conclusions that emerged during their conversations.
 
 ![Community organisers participating in an open space discussion at EuroPython 2025](./community-organisers-open-space.jpg)

--- a/src/data/nav.ts
+++ b/src/data/nav.ts
@@ -48,7 +48,7 @@ const L = {
   rustSummit: { label: "Rust Summit", url: "/rust-summit" },
   packagingSummit: { label: "Packaging Summit", url: "/packaging-summit" },
   communityOrganisersSummit: {
-    label: "Organisers Summit",
+    label: "Community Organisers Summit",
     url: "/community-organisers-summit",
   },
 


### PR DESCRIPTION
@nikoshell Let's fix the overflow of "Community Organisers Summit" in the nav menu as well!