### PR TITLE
Show 'Lunch' on mobile schedule

### DIFF
--- a/src/components/schedule/day.astro
+++ b/src/components/schedule/day.astro
@@ -738,6 +738,10 @@ const endStart = numberToTime(lastEndTime);
       text-align: center;
     }
 
+    .lunch-break-header {
+      display: block;
+    }
+
     /* Override inline grid on mobile — fits viewport */
     .lunch-break .lunch-break-content {
       display: block !important;


### PR DESCRIPTION
Fixes https://github.com/EuroPython/website/issues/1809.

Before:

<img width="282" height="572" alt="image" src="https://github.com/user-attachments/assets/cbe88658-2d5b-4771-bdd2-9b53056d6e74" />


After:

<img width="286" height="575" alt="image" src="https://github.com/user-attachments/assets/80117431-0b35-44c3-b5bf-c4411cae94ff" />

http://localhost:4321/schedule/talks#day-2026-07-16