### PR TITLE
Add GPU MODE Cholesky sprint

### DIFF
--- a/src/components/Header.astro
+++ b/src/components/Header.astro
@@ -614,14 +614,18 @@ const activeMenus = NAV_MENUS.map((menu) => ({
 
 <script>
   document.addEventListener("DOMContentLoaded", function () {
-    const navbar = document.getElementById("navbar");
-    if (!navbar) return;
+    const navbarElement = document.getElementById("navbar");
+    if (!navbarElement) return;
+    const navbar = navbarElement;
 
     // ── Mobile hamburger toggle ──
-    const toggle = navbar.querySelector(".nav-toggle");
-    const navLinks = navbar.querySelector(".nav-links");
+    const toggleElement =
+      navbar.querySelector<HTMLButtonElement>(".nav-toggle");
+    const navLinksElement = navbar.querySelector<HTMLElement>(".nav-links");
 
-    if (toggle && navLinks) {
+    if (toggleElement && navLinksElement) {
+      const toggle = toggleElement;
+      const navLinks = navLinksElement;
       function closeMenuMob() {
         navLinks.classList.remove("open");
         toggle.classList.remove("active");
@@ -697,7 +701,7 @@ const activeMenus = NAV_MENUS.map((menu) => ({
       return parseInt(getComputedStyle(navbar).top) || 0;
     }
 
-    function setBannerState(atTop) {
+    function setBannerState(atTop: boolean) {
       if (!banner) return;
       if (atTop) {
         banner.style.transform = "translateY(0)";
@@ -760,7 +764,7 @@ const activeMenus = NAV_MENUS.map((menu) => ({
     }
     window.addEventListener("scroll", requestTick, { passive: true });
 
-    let bounceCheck = null;
+    let bounceCheck: ReturnType<typeof setTimeout> | null = null;
     window.addEventListener(
       "scroll",
       function () {

--- a/src/content/sprints/gpu-mode-cholesky.md
+++ b/src/content/sprints/gpu-mode-cholesky.md
@@ -44,6 +44,9 @@ its performance evidence, and keep numerically incorrect changes off the
 leaderboard. Working directly by hand, pairing with another person, or bringing
 your preferred coding agent are all equally welcome.
 
+NVIDIA will provide participants with a free sandbox VM and inference keys for
+the purposes of the contest.
+
 No previous GPU-kernel or agent experience is required. Bring a laptop and a
 GitHub or Discord account for authentication; basic Python familiarity will
 help.

--- a/src/content/sprints/gpu-mode-cholesky.md
+++ b/src/content/sprints/gpu-mode-cholesky.md
@@ -31,18 +31,18 @@ The benchmark ranges from thousands of small matrices to one 32768-by-32768
 matrix, leaving room for many different ideas. Tests and benchmarks run on
 hosted B200s, so you do not need a local GPU.
 
-Bryce will help participants install and register the Popcorn CLI, understand
-the problem, make a first correct submission, read benchmark and profiling
-results, and choose an optimization to try. The goal is for every newcomer to
-leave knowing the complete contest workflow; experienced GPU programmers are
-welcome to team up and chase the leaderboard.
+Bryce from NVIDIA will help participants install and register the Popcorn CLI,
+understand the problem, make a first correct submission, read benchmark and
+profiling results, and choose an optimization to try. The goal is for every
+newcomer to leave knowing the complete contest workflow; experienced GPU
+programmers are welcome to team up and chase the leaderboard.
 
-Agentic GPU programming will be a first-class track. Popcorn can scaffold skills
-for coding agents, allowing participants to explore an iterative
-edit-test-benchmark loop while learning how to give an agent useful direction,
-check its evidence, and protect numerical correctness. Working directly by hand,
-pairing with another person, or bringing your preferred coding agent are all
-equally welcome.
+Participants who want to use a coding agent can have Popcorn scaffold the
+agent's contest workflow. Bryce will show how to give an agent a concrete
+optimization goal, let it run the iterative edit-test-benchmark loop, inspect
+its performance evidence, and keep numerically incorrect changes off the
+leaderboard. Working directly by hand, pairing with another person, or bringing
+your preferred coding agent are all equally welcome.
 
 No previous GPU-kernel or agent experience is required. Bring a laptop and a
 GitHub or Discord account for authentication; basic Python familiarity will

--- a/src/content/sprints/gpu-mode-cholesky.md
+++ b/src/content/sprints/gpu-mode-cholesky.md
@@ -1,0 +1,49 @@
+---
+title: "GPU MODE: Cholesky Challenge"
+numberOfPeople: "20"
+pythonLevel: "Any"
+contactPerson:
+  name: "Bryce Adelstein Lelbach"
+  email: "brycelelbach@gmail.com"
+  github: "brycelelbach"
+  twitter: "blelbach"
+links:
+  - title: "Cholesky leaderboard"
+    url: "https://www.gpumode.com/leaderboard/776"
+  - title: "Cholesky problem and starter submission"
+    url: "https://github.com/gpu-mode/reference-kernels/tree/main/problems/linalg/cholesky_py"
+  - title: "Linear algebra competition announcement"
+    url: "https://www.gpumode.com/news/linear-algebra-kernels-age-of-research"
+  - title: "Popcorn CLI"
+    url: "https://github.com/gpu-mode/popcorn-cli"
+  - title: "GPU MODE Discord"
+    url: "https://discord.gg/gpumode"
+---
+
+Come learn how to compete in a GPU MODE kernel contest by tackling the new
+Cholesky problem together. The challenge is to factor batches of symmetric
+positive-definite FP32 matrices on an NVIDIA B200. It runs through 30 July, so
+we can put what we learn straight onto the live leaderboard.
+
+Every submission is a single Python file. You can begin with the working PyTorch
+baseline, then optimize in Python with tools such as Triton or embedded CUDA.
+The benchmark ranges from thousands of small matrices to one 32768-by-32768
+matrix, leaving room for many different ideas. Tests and benchmarks run on
+hosted B200s, so you do not need a local GPU.
+
+Bryce will help participants install and register the Popcorn CLI, understand
+the problem, make a first correct submission, read benchmark and profiling
+results, and choose an optimization to try. The goal is for every newcomer to
+leave knowing the complete contest workflow; experienced GPU programmers are
+welcome to team up and chase the leaderboard.
+
+Agentic GPU programming will be a first-class track. Popcorn can scaffold skills
+for coding agents, allowing participants to explore an iterative
+edit-test-benchmark loop while learning how to give an agent useful direction,
+check its evidence, and protect numerical correctness. Working directly by hand,
+pairing with another person, or bringing your preferred coding agent are all
+equally welcome.
+
+No previous GPU-kernel or agent experience is required. Bring a laptop and a
+GitHub or Discord account for authentication; basic Python familiarity will
+help.


### PR DESCRIPTION
Adds a EuroPython sprint for the new GPU MODE Cholesky challenge, led by Bryce Adelstein Lelbach.

The proposal highlights:

- the single-file Python submission format and PyTorch, Triton, or embedded-CUDA paths
- the live B200 challenge and hosted compute, with no local GPU required
- a newcomer-friendly path from setup to a first valid leaderboard score
- an optional agentic edit-test-benchmark workflow with human direction and correctness checks

The mandatory local pre-commit check exposed existing Header.astro nullability errors. This PR includes a narrow, behavior-preserving typing fix so the hook can complete; the sprint content itself is isolated in src/content/sprints/gpu-mode-cholesky.md.

Validation:

- pnpm astro check
- pnpm exec prettier --check src/content/sprints/gpu-mode-cholesky.md
- pnpm exec astro build --mode production
- pnpm pagefind

<!-- readthedocs-preview ep-website start -->
🖼️ Preview available 🖼️ : https://ep-website--1829.org.readthedocs.build/
<!-- readthedocs-preview ep-website end -->