### PR TITLE
enh: add pyOpenSci to sprint projects

### DIFF
--- a/src/content/sprints/pyopensci.md
+++ b/src/content/sprints/pyopensci.md
@@ -6,12 +6,9 @@ contactPerson: # The main person to reach out to regarding the sprint.
   name: "Leah Wasser"
   email: leah@pyopensci.org
   github: lwasser
-  twitter: NA
 links: # Add as many links as relevant.
   - title: "pyOpenSci Help Wanted Project Board"
-    url:
-      "[[Help Wanted
-      Issues](https://github.com/orgs/pyOpenSci/projects/3/views/2)](https://github.com/orgs/pyOpenSci/projects/3/views/2)"
+    url: https://github.com/orgs/pyOpenSci/projects/3/views/2"
 ---
 
 Hi Friends! pyOpenSci runs beginner friendly sprints that anyone can attend.

--- a/src/content/sprints/pyopensci.md
+++ b/src/content/sprints/pyopensci.md
@@ -8,7 +8,7 @@ contactPerson: # The main person to reach out to regarding the sprint.
   github: lwasser
 links: # Add as many links as relevant.
   - title: "pyOpenSci Help Wanted Project Board"
-    url: https://github.com/orgs/pyOpenSci/projects/3/views/2"
+    url: "https://github.com/orgs/pyOpenSci/projects/3/views/2"
 ---
 
 Hi Friends! pyOpenSci runs beginner friendly sprints that anyone can attend.

--- a/src/content/sprints/pyopensci.md
+++ b/src/content/sprints/pyopensci.md
@@ -1,0 +1,20 @@
+---
+title: "pyOpenSci"
+numberOfPeople: "10" # How many people you expect to be able to accommodate.
+pythonLevel: "Any" # Any, Beginner, Intermediate, or Advanced.
+contactPerson: # The main person to reach out to regarding the sprint.
+  name: "Leah Wasser"
+  email: leah@pyopensci.org   
+  github: lwasser
+  twitter: NA
+links: # Add as many links as relevant.
+  - title: "pyOpenSci Help Wanted Project Board"
+    url: "[[Help Wanted Issues](https://github.com/orgs/pyOpenSci/projects/3/views/2)](https://github.com/orgs/pyOpenSci/projects/3/views/2)"
+---
+
+Hi Friends! pyOpenSci runs beginner friendly sprints that anyone can attend. However we also 
+have some more advanced infrastructure if you are interested in supporting us during the sprint.
+
+This year we will be sprinting on translations for our packaging guide. 
+You can also check out our help wanted project board to see the types of other issues we have open that may 
+peak your interest! 

--- a/src/content/sprints/pyopensci.md
+++ b/src/content/sprints/pyopensci.md
@@ -4,17 +4,20 @@ numberOfPeople: "10" # How many people you expect to be able to accommodate.
 pythonLevel: "Any" # Any, Beginner, Intermediate, or Advanced.
 contactPerson: # The main person to reach out to regarding the sprint.
   name: "Leah Wasser"
-  email: leah@pyopensci.org   
+  email: leah@pyopensci.org
   github: lwasser
   twitter: NA
 links: # Add as many links as relevant.
   - title: "pyOpenSci Help Wanted Project Board"
-    url: "[[Help Wanted Issues](https://github.com/orgs/pyOpenSci/projects/3/views/2)](https://github.com/orgs/pyOpenSci/projects/3/views/2)"
+    url:
+      "[[Help Wanted
+      Issues](https://github.com/orgs/pyOpenSci/projects/3/views/2)](https://github.com/orgs/pyOpenSci/projects/3/views/2)"
 ---
 
-Hi Friends! pyOpenSci runs beginner friendly sprints that anyone can attend. However we also 
-have some more advanced infrastructure if you are interested in supporting us during the sprint.
+Hi Friends! pyOpenSci runs beginner friendly sprints that anyone can attend.
+However we also have some more advanced infrastructure if you are interested in
+supporting us during the sprint.
 
-This year we will be sprinting on translations for our packaging guide. 
-You can also check out our help wanted project board to see the types of other issues we have open that may 
-peak your interest! 
+This year we will be sprinting on translations for our packaging guide. You can
+also check out our help wanted project board to see the types of other issues we
+have open that may peak your interest!


### PR DESCRIPTION
Added details about the pyOpenSci sprint, including contact information and links.

<!-- readthedocs-preview ep-website start -->
🖼️ Preview available 🖼️ : https://ep-website--1832.org.readthedocs.build/
<!-- readthedocs-preview ep-website end -->