### PR TITLE
Create sprint document for (Py)Arrow

### DIFF
--- a/src/content/sprints/pyarrow.md
+++ b/src/content/sprints/pyarrow.md
@@ -13,12 +13,12 @@ links: # Add as many links as relevant.
     url: "https://github.com/apache/arrow/issues"
 ---
 
-Apache Arrow is a universal columnar format and multi-language toolbox for
-fast data interchange and in-memory analytics.
+Apache Arrow is a universal columnar format and multi-language toolbox for fast
+data interchange and in-memory analytics.
 
-The project specifies a language-independent column-oriented memory format
-for flat and hierarchical data, organized for efficient analytic operations
-on modern hardware. 
+The project specifies a language-independent column-oriented memory format for
+flat and hierarchical data, organized for efficient analytic operations on
+modern hardware.
 
-Do you want to discuss something (Py)Arrow related?
-Let's discuss usage, issues, PRs, roadmap we'll be there on Saturday.
+Do you want to discuss something (Py)Arrow related? Let's discuss usage, issues,
+PRs, roadmap we'll be there on Saturday.

--- a/src/content/sprints/pyarrow.md
+++ b/src/content/sprints/pyarrow.md
@@ -1,0 +1,24 @@
+---
+title: "(Py)Arrow"
+numberOfPeople: "5" # How many people you expect to be able to accommodate.
+pythonLevel: "Any" # Any, Beginner, Intermediate, or Advanced.
+contactPerson: # The main person to reach out to regarding the sprint.
+  name: "Rok Mihevc"
+  email: "rok.mihevc@gmail.com"
+  github: "rok"
+links: # Add as many links as relevant.
+  - title: "PyArrow developer guide"
+    url: "https://arrow.apache.org/docs/developers/python/development.html"
+  - title: "Arrow issue tracker"
+    url: "https://github.com/apache/arrow/issues"
+---
+
+Apache Arrow is a universal columnar format and multi-language toolbox for
+fast data interchange and in-memory analytics.
+
+The project specifies a language-independent column-oriented memory format
+for flat and hierarchical data, organized for efficient analytic operations
+on modern hardware. 
+
+Do you want to discuss something (Py)Arrow related?
+Let's discuss usage, issues, PRs, roadmap we'll be there on Saturday.


### PR DESCRIPTION
Added a new sprint document for (Py)Arrow including details about the event, contact person, and relevant links.

<!-- readthedocs-preview ep-website start -->
🖼️ Preview available 🖼️ : https://ep-website--1834.org.readthedocs.build/
<!-- readthedocs-preview ep-website end -->