### PR TITLE
feat: disable links no longer relevant post-conference

### DIFF
--- a/src/components/Header.astro
+++ b/src/components/Header.astro
@@ -111,12 +111,15 @@ const activeMenus = NAV_MENUS.map((menu) => ({
           ),
         )
     }
+    <!--
+    TODO: Re-enable next year!
     <li class="nav-item nav-mobile-cta">
       <a class="nav-link-btn" href="/jobs">Jobs</a>
     </li>
     <li class="nav-item nav-mobile-cta">
       <a class="nav-link-btn" href="/tickets">Register Now</a>
     </li>
+    -->
   </ul>
 
   <button
@@ -140,6 +143,8 @@ const activeMenus = NAV_MENUS.map((menu) => ({
       <line x1="21" y1="21" x2="16.65" y2="16.65"></line>
     </svg>
   </button>
+  <!--
+  TODO: Re-enable next year!
   <a
     href="/discord"
     class="nav-icon-btn"
@@ -159,9 +164,13 @@ const activeMenus = NAV_MENUS.map((menu) => ({
       ></path>
     </svg>
   </a>
+  -->
   <ThemeToggle />
+  <!--
+  TODO: Re-enable next year!
   <a href="/jobs" class="nav-cta-desktop">Jobs</a>
   <a href="/tickets" class="nav-cta">Register Now</a>
+  -->
   <button
     class="nav-toggle"
     aria-label="Toggle menu"
@@ -181,7 +190,8 @@ const activeMenus = NAV_MENUS.map((menu) => ({
 
   nav {
     position: fixed;
-    top: 40px;
+    /* top: 40px when #ep-banner HTML is enabled in Layout.astro */
+    top: 0;
     left: 0;
     right: 0;
     z-index: 1000;

--- a/src/components/sections/hero/hero.astro
+++ b/src/components/sections/hero/hero.astro
@@ -42,10 +42,8 @@ PYTHON">
         > 18–23 July
       </p>
       <div class="hero-cta-row">
-        <!--
-        TODO: Re-enable next year!
-        <a href="/tickets" class="hero-cta">Register Now</a>
-        -->
+        <!-- TODO: Re-enable next year! -->
+        <!-- <a href="/tickets" class="hero-cta">Register Now</a> -->
         <a href="#programme" class="hero-cta-alt">View Programme</a>
       </div>
       <div class="hero-flowers" aria-hidden="true">

--- a/src/components/sections/hero/hero.astro
+++ b/src/components/sections/hero/hero.astro
@@ -42,7 +42,10 @@ PYTHON">
         > 18–23 July
       </p>
       <div class="hero-cta-row">
+        <!--
+        TODO: Re-enable next year!
         <a href="/tickets" class="hero-cta">Register Now</a>
+        -->
         <a href="#programme" class="hero-cta-alt">View Programme</a>
       </div>
       <div class="hero-flowers" aria-hidden="true">

--- a/src/data/nav.ts
+++ b/src/data/nav.ts
@@ -65,10 +65,11 @@ const L = {
   },
 
   // Participate
-  tickets: { label: "Tickets", url: "/tickets" },
-  remote: { label: "Remote", url: "/remote" },
+  // TODO: Re-enable next year!
+  // tickets: { label: "Tickets", url: "/tickets" },
+  // remote: { label: "Remote", url: "/remote" },
   finaid: { label: "Financial Aid", url: "/finaid" },
-  visa: { label: "Visa Information", url: "/visa" },
+  // visa: { label: "Visa Information", url: "/visa" },
   volunteering: { label: "Volunteering", url: "/volunteering" },
   faq: { label: "FAQ", url: "/faq" },
   coc: {
@@ -179,26 +180,27 @@ export const NAV_MENUS: NavMenu[] = [
     ],
   },
 
-  // Attend — simple flat list
-  {
-    label: "Attend",
-    url: "/tickets",
-    sections: [
-      {
-        items: [
-          L.tickets,
-          L.remote,
-          L.finaid,
-          L.visa,
-          L.volunteering,
-          L.faq,
-          L.coc,
-          L.accessibility,
-          L.childcare,
-        ],
-      },
-    ],
-  },
+  // TODO: Re-enable next year!
+  // Attend
+  // {
+  //   label: "Attend",
+  //   url: "/tickets",
+  //   sections: [
+  //     {
+  //       items: [
+  //         L.tickets,
+  //         L.remote,
+  //         L.finaid,
+  //         L.visa,
+  //         L.volunteering,
+  //         L.faq,
+  //         L.coc,
+  //         L.accessibility,
+  //         L.childcare,
+  //       ],
+  //     },
+  //   ],
+  // },
 
   // Venue — simple flat list
   {
@@ -270,7 +272,9 @@ export const TERMS: Link[] = [
 export const FOOTER_COLUMNS: FooterColumn[] = [
   {
     title: "Quick links",
-    items: [L.tickets, L.remote, L.krakow, L.visa],
+    // TODO: Re-enable next year!
+    // items: [L.tickets, L.remote, L.krakow, L.visa],
+    items: [L.krakow],
   },
   {
     title: "Programme",

--- a/src/layouts/Layout.astro
+++ b/src/layouts/Layout.astro
@@ -60,8 +60,9 @@ const hideFooter = Astro.props.hideFooter ?? false;
   </head>
   <body>
     <!-- ═══════════════════════════════════════════
-         OLD-EUROPYTHON BANNER
-         ═══════════════════════════════════════════ -->
+         OLD-EUROPYTHON BANNER (disabled — uncomment to re-enable)
+         When enabling: also set nav { top: 40px } in Header.astro
+         ═══════════════════════════════════════════
     <a
       id="ep-banner"
       href="/remote"
@@ -69,6 +70,7 @@ const hideFooter = Astro.props.hideFooter ?? false;
     >
       Can’t join us in Kraków? Attend remotely — online options available!
     </a>
+    -->
     {
       !hideHeader && (
         <header>


### PR DESCRIPTION
This pull request primarily disables ticketing- and attendance-related navigation and call-to-action elements throughout the site, in preparation for the event's conclusion or for maintenance until next year. The changes are wrapped in comments with TODO notes for easy re-enabling in the future. It also updates navigation positioning and clarifies the handling of the old event banner.

Navigation and CTA removals:

* Commented out or removed "Tickets," "Register Now," "Jobs," and "Attend" menu items and links from the header, hero section, and navigation data, with clear TODOs for re-enabling next year (`src/components/Header.astro`, `src/components/sections/hero/hero.astro`, `src/data/nav.ts`) [[1]](diffhunk://#diff-cef92c86af879f90a7ac8087da782381ed31160251d9960fe59f7ee29389a9beR114-R122) [[2]](diffhunk://#diff-cef92c86af879f90a7ac8087da782381ed31160251d9960fe59f7ee29389a9beR146-R147) [[3]](diffhunk://#diff-cef92c86af879f90a7ac8087da782381ed31160251d9960fe59f7ee29389a9beR167-R173) [[4]](diffhunk://#diff-c3bd67d328da359bba94296080fd6c05aef7d80d78414b8ede4269f33d2b62b9L68-R72) [[5]](diffhunk://#diff-c3bd67d328da359bba94296080fd6c05aef7d80d78414b8ede4269f33d2b62b9L182-R203) [[6]](diffhunk://#diff-c3bd67d328da359bba94296080fd6c05aef7d80d78414b8ede4269f33d2b62b9L273-R277) [[7]](diffhunk://#diff-da068374378067517aa040bcea0a9eecf0b198d44f7bf0f0fdd69b9af62fcac6L45-R46).

Navigation layout adjustment:

* Changed the `nav` CSS `top` property from `40px` to `0` to accommodate the (now disabled) event banner, with a comment explaining when to revert this change (`src/components/Header.astro`).

Event banner handling:

* Updated comments and instructions around the old event banner in the main layout, clarifying how to re-enable it and coordinate with navigation layout (`src/layouts/Layout.astro`).

These changes ensure that users no longer see outdated CTAs or navigation items, and make it straightforward to restore them for future events.